### PR TITLE
fix: no more panic on empty env variables

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,7 +3,7 @@ name: cosignwebhook
 description: A Helm chart for Cosign Webhook Admission Controller
 type: application
 version: 4.0.0
-appVersion: "4.0.1"
+appVersion: "4.0.2"
 maintainers:
   - name: eumel8
     email: f.kloeker@telekom.de

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/eumel8/cosignwebhook/cosignwebhook
   pullPolicy: IfNotPresent
-  tag: 4.0.0
+  tag: 4.0.2
 
 imagePullSecrets: []
 logLevel: info

--- a/webhook/cosignwebhook.go
+++ b/webhook/cosignwebhook.go
@@ -97,7 +97,7 @@ func (csh *CosignServerHandler) recordEvent(p *corev1.Pod) {
 	eventBroadcaster.Shutdown()
 }
 
-// get container object from admission request
+// getPod returns the pod object from admission review request
 func getPod(byte []byte) (*corev1.Pod, *v1.AdmissionReview, error) {
 	arRequest := v1.AdmissionReview{}
 	if err := json.Unmarshal(byte, &arRequest); err != nil {
@@ -127,7 +127,7 @@ func (csh *CosignServerHandler) getPubKeyFromEnv(c *corev1.Container, ns string)
 				return envVar.Value, nil
 			}
 
-			if envVar.ValueFrom.SecretKeyRef != nil {
+			if envVar.ValueFrom != nil && envVar.ValueFrom.SecretKeyRef != nil {
 				log.Debugf("Found reference to public key in secret %q for container %q", envVar.ValueFrom.SecretKeyRef.Name, c.Name)
 				return csh.getSecretValue(ns,
 					envVar.ValueFrom.SecretKeyRef.Name,
@@ -246,7 +246,7 @@ func (csh *CosignServerHandler) Serve(w http.ResponseWriter, r *http.Request) {
 
 // verifyContainer verifies the signature of the container image
 func (csh *CosignServerHandler) verifyContainer(c *corev1.Container, ns string) error {
-	log.Debugf("Inspecting container %q in namespace %q", ns, c.Name)
+	log.Debugf("Inspecting container %q in namespace %q", c.Name, ns)
 	// Get public key from environment var
 	pubKey, err := csh.getPubKeyFromEnv(c, ns)
 	if err != nil {

--- a/webhook/cosignwebhook_test.go
+++ b/webhook/cosignwebhook_test.go
@@ -93,6 +93,19 @@ func Test_getPubKeyFromEnv(t *testing.T) {
 			want:          "",
 			wantErr:       true,
 		},
+		{
+			name: "cosign key without value",
+			container: &corev1.Container{
+				Env: []corev1.EnvVar{
+					{
+						Name: CosignEnvVar,
+					},
+				},
+			},
+			secretPresent: false,
+			want:          "",
+			wantErr:       true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Motivation

Fixes #26 

## Changes

- Added a simple if check to make sure the envFrom is not nil before accessing it.
- Added a test to make sure something similar doesn't happen again

