### PR TITLE
Feat/noverification event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 cosignwebhook
 chart/caas-values.yaml
-vendor
 
 # the keypair used for test-signing of the webhook
 *.key

--- a/Makefile
+++ b/Makefile
@@ -68,3 +68,10 @@ e2e-deploy:
 		--wait --debug
 
 e2e-prep: e2e-cluster e2e-keys e2e-images e2e-deploy
+
+e2e-cleanup:
+	@echo "Cleaning up..."
+	@helm uninstall cosignwebhook -n cosignwebhook
+	@k3d registry delete k3d-registry.localhost
+	@k3d cluster delete cosign-tests
+	@rm -f cosign.pub cosign.key second.pub second.key

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 [![Project Status: Active](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![Go Report Card](https://goreportcard.com/badge/github.com/eumel8/cosignwebhook)](https://goreportcard.com/report/github.com/eumel8/cosignwebhook)
 [![Release](https://img.shields.io/github/v/release/eumel8/cosignwebhook?display_name=tag)](https://github.com/eumel8/cosignwebhook/releases)
@@ -8,7 +7,6 @@
 [![Pipeline](https://github.com/eumel8/cosignwebhook/actions/workflows/end2end.yaml/badge.svg)](https://github.com/eumel8/cosignwebhook/actions/workflows/end2end.yaml)
 [![Pipeline](https://github.com/eumel8/cosignwebhook/actions/workflows/build.yaml/badge.svg)]([https://github.com/eumel8/cosignwebhook/actions/workflows/build.yaml)
 [![Pipeline](https://github.com/eumel8/cosignwebhook/actions/workflows/trivy.yaml/badge.svg)]([https://github.com/eumel8/cosignwebhook/actions/workflows/trivy.yaml)
-
 
 # Cosign Webhook
 
@@ -128,10 +126,20 @@ make test-e2e
 
 ## E2E tests
 
-The E2E tests require a running kubernetes cluster. Currently, the namespace and webhook are deployed via helper make targets. To run the tests the following is required:
+The E2E tests require a running kubernetes cluster. Currently, the namespace and webhook are deployed via helper make
+targets. To run the tests the following is required:
 
 - docker
 - cosign (v2)
+
+To run the E2E tests, the following steps are required (in order):
+
+- signing keys are generated (`make e2e-keys`)
+- a new `cosignwebhook` image is build and signed with a temp key (`make e2e-images`)
+- the image is pushed to a local registry & deployed to the test cluster (`make e2e-deploy`)
+
+To do all of the above, simply run `make e2e-prep`. Each step should also be able to be executed individually. To clean
+up the E2E setup, run `make e2e-cleanup`. This will delete everything created by the E2E preparation.
 
 # TODO
 

--- a/test/framework/client.go
+++ b/test/framework/client.go
@@ -50,14 +50,12 @@ func createClientSet() (k8sClient *kubernetes.Clientset, err error) {
 }
 
 // Cleanup removes all resources created by the framework
-// and cleans up the testing directory
-func (f *Framework) Cleanup(t testing.TB, err error) {
+// and cleans up the testing directory. If an error is passed,
+// the test will fail but the cleanup will still be executed.
+func (f *Framework) Cleanup(t testing.TB) {
 	cleanupKeys(t)
 	f.cleanupDeployments(t)
 	f.cleanupSecrets(t)
-	if err != nil {
-		t.Fatalf("test failed: %v", err)
-	}
 }
 
 // cleanupDeployments removes all deployments from the testing namespace
@@ -67,12 +65,15 @@ func (f *Framework) cleanupDeployments(t testing.TB) {
 	t.Logf("cleaning up deployments")
 	deployments, err := f.k8s.AppsV1().Deployments("test-cases").List(context.Background(), metav1.ListOptions{})
 	if err != nil {
-		f.Cleanup(t, err)
+		f.Cleanup(t)
+		t.Fatal(err)
+
 	}
 	for _, d := range deployments.Items {
 		err = f.k8s.AppsV1().Deployments("test-cases").Delete(context.Background(), d.Name, metav1.DeleteOptions{})
 		if err != nil {
-			f.Cleanup(t, err)
+			f.Cleanup(t)
+			t.Fatal(err)
 		}
 	}
 
@@ -80,11 +81,12 @@ func (f *Framework) cleanupDeployments(t testing.TB) {
 	for {
 		select {
 		case <-timeout:
-			f.Cleanup(t, fmt.Errorf("timeout reached while waiting for deployments to be deleted"))
+			f.Cleanup(t)
 		default:
 			pods, err := f.k8s.CoreV1().Pods("test-cases").List(context.Background(), metav1.ListOptions{})
 			if err != nil {
-				f.Cleanup(t, err)
+				f.Cleanup(t)
+				t.Fatal(err)
 			}
 
 			if len(pods.Items) == 0 {
@@ -102,7 +104,8 @@ func (f *Framework) cleanupSecrets(t testing.TB) {
 	t.Logf("cleaning up secrets")
 	secrets, err := f.k8s.CoreV1().Secrets("test-cases").List(context.Background(), metav1.ListOptions{})
 	if err != nil {
-		f.Cleanup(t, err)
+		f.Cleanup(t)
+		t.Fatal(err)
 	}
 	if len(secrets.Items) == 0 {
 		return
@@ -110,7 +113,8 @@ func (f *Framework) cleanupSecrets(t testing.TB) {
 	for _, s := range secrets.Items {
 		err = f.k8s.CoreV1().Secrets("test-cases").Delete(context.Background(), s.Name, metav1.DeleteOptions{})
 		if err != nil {
-			f.Cleanup(t, err)
+			f.Cleanup(t)
+			t.Fatal(err)
 		}
 	}
 }
@@ -119,7 +123,8 @@ func (f *Framework) cleanupSecrets(t testing.TB) {
 func (f *Framework) CreateDeployment(t testing.TB, d appsv1.Deployment) {
 	_, err := f.k8s.AppsV1().Deployments("test-cases").Create(context.Background(), &d, metav1.CreateOptions{})
 	if err != nil {
-		f.Cleanup(t, err)
+		f.Cleanup(t)
+		t.Fatal(err)
 	}
 }
 
@@ -133,14 +138,16 @@ func (f *Framework) WaitForDeployment(t *testing.T, d appsv1.Deployment) {
 	})
 
 	if err != nil {
-		f.Cleanup(t, err)
+		f.Cleanup(t)
+		t.Fatal(err)
 	}
 
 	timeout := time.After(30 * time.Second)
 	for event := range w.ResultChan() {
 		select {
 		case <-timeout:
-			f.Cleanup(t, fmt.Errorf("timeout reached while waiting for deployment to be ready"))
+			f.Cleanup(t)
+			t.Fatal("timeout reached while waiting for deployment to be ready")
 		default:
 			deployment, ok := event.Object.(*appsv1.Deployment)
 			if !ok {
@@ -156,7 +163,8 @@ func (f *Framework) WaitForDeployment(t *testing.T, d appsv1.Deployment) {
 		}
 	}
 
-	f.Cleanup(t, fmt.Errorf("failed to wait for deployment to be ready"))
+	f.Cleanup(t)
+	t.Fatal("failed to wait for deployment to be ready")
 }
 
 // CreateSecret creates a secret in the testing namespace
@@ -164,7 +172,8 @@ func (f *Framework) CreateSecret(t *testing.T, secret corev1.Secret) {
 	t.Logf("creating secret %s", secret.Name)
 	s, err := f.k8s.CoreV1().Secrets("test-cases").Create(context.Background(), &secret, metav1.CreateOptions{})
 	if err != nil {
-		f.Cleanup(t, err)
+		f.Cleanup(t)
+		t.Fatal(err)
 	}
 	t.Logf("created secret %s", s.Name)
 }
@@ -177,7 +186,8 @@ func (f *Framework) AssertDeploymentFailed(t *testing.T, d appsv1.Deployment) {
 	// watch for replicasets of the deployment
 	rsName, err := f.waitForReplicaSetCreation(t, d)
 	if err != nil {
-		f.Cleanup(t, err)
+		f.Cleanup(t)
+		t.Fatal(err)
 	}
 
 	// get warning events of deployment's namespace and check if the deployment failed
@@ -185,14 +195,16 @@ func (f *Framework) AssertDeploymentFailed(t *testing.T, d appsv1.Deployment) {
 		FieldSelector: fmt.Sprintf("involvedObject.name=%s", rsName),
 	})
 	if err != nil {
-		f.Cleanup(t, err)
+		f.Cleanup(t)
+		t.Fatal(err)
 	}
 
 	timeout := time.After(30 * time.Second)
 	for event := range w.ResultChan() {
 		select {
 		case <-timeout:
-			f.Cleanup(t, fmt.Errorf("timeout reached while waiting for deployment to fail"))
+			f.Cleanup(t)
+			t.Fatal("timeout reached while waiting for deployment to fail")
 		default:
 			e, ok := event.Object.(*corev1.Event)
 			if !ok {
@@ -208,12 +220,48 @@ func (f *Framework) AssertDeploymentFailed(t *testing.T, d appsv1.Deployment) {
 	}
 }
 
+// AssertEventForPod asserts that a PodVerified event is created
+func (f *Framework) AssertEventForPod(t *testing.T, reason string, p corev1.Pod) {
+
+	t.Logf("waiting for %s event to be created for pod %s", reason, p.Name)
+
+	// watch for events of deployment's namespace and check if the podverified event is created
+	w, err := f.k8s.CoreV1().Events("test-cases").Watch(context.Background(), metav1.ListOptions{
+		FieldSelector: fmt.Sprintf("involvedObject.name=%s", p.Name),
+	})
+	if err != nil {
+		f.Cleanup(t)
+		t.Fatal(err)
+	}
+
+	timeout := time.After(30 * time.Second)
+	for event := range w.ResultChan() {
+		select {
+		case <-timeout:
+			f.Cleanup(t)
+			t.Fatal("timeout reached while waiting for podverified event")
+		default:
+			e, ok := event.Object.(*corev1.Event)
+			if !ok {
+				time.Sleep(5 * time.Second)
+				continue
+			}
+			if e.Reason == reason {
+				t.Logf("%s event created for pod %s", reason, p.Name)
+				return
+			}
+			time.Sleep(5 * time.Second)
+		}
+	}
+}
+
 func (f *Framework) waitForReplicaSetCreation(t *testing.T, d appsv1.Deployment) (string, error) {
 	rs, err := f.k8s.AppsV1().ReplicaSets("test-cases").Watch(context.Background(), metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("app=%s", d.Name),
 	})
 	if err != nil {
-		f.Cleanup(t, err)
+		f.Cleanup(t)
+		t.Fatal(err)
 	}
 
 	timeout := time.After(30 * time.Second)
@@ -231,4 +279,17 @@ func (f *Framework) waitForReplicaSetCreation(t *testing.T, d appsv1.Deployment)
 		}
 	}
 	return "", fmt.Errorf("failed to wait for replicaset creation")
+}
+
+// GetPods returns the pod(s) of the deployment. The fetch is done by label selector (app=<deployment name>)
+// If the get request fails, the test will fail and the framework will be cleaned up
+func (f *Framework) GetPods(t *testing.T, d appsv1.Deployment) *corev1.PodList {
+	pods, err := f.k8s.CoreV1().Pods("test-cases").List(context.Background(), metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("app=%s", d.Name),
+	})
+	if err != nil {
+		f.Cleanup(t)
+		t.Fatal(err)
+	}
+	return pods
 }

--- a/test/framework/cosign.go
+++ b/test/framework/cosign.go
@@ -43,17 +43,17 @@ func (f *Framework) CreateKeys(t testing.TB, name string) (string, string) {
 	cmd.SetArgs(args)
 	err = cmd.Execute()
 	if err != nil {
-		f.Cleanup(t, err)
+		f.Cleanup(t)
 	}
 
 	// read private key and public key from the current directory
 	privateKey, err := os.ReadFile(fmt.Sprintf("%s.key", name))
 	if err != nil {
-		f.Cleanup(t, err)
+		f.Cleanup(t)
 	}
 	pubKey, err := os.ReadFile(fmt.Sprintf("%s.pub", name))
 	if err != nil {
-		f.Cleanup(t, err)
+		f.Cleanup(t)
 	}
 
 	return string(privateKey), string(pubKey)
@@ -86,6 +86,6 @@ func (f *Framework) SignContainer(t *testing.T, priv, img string) {
 	_ = cmd.Flags().Set("allow-http-registry", "true")
 	err := cmd.Execute()
 	if err != nil {
-		f.Cleanup(t, err)
+		f.Cleanup(t)
 	}
 }

--- a/test/main_test.go
+++ b/test/main_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 )
 
+// TestPassingDeployments tests deployments that should pass signature verification
 func TestPassingDeployments(t *testing.T) {
 
 	testFuncs := map[string]func(t *testing.T){
@@ -13,6 +14,8 @@ func TestPassingDeployments(t *testing.T) {
 		"TwoContainersSinglePubKeyMixedRef":         testTwoContainersSinglePubKeyMixedRef,
 		"TwoContainersMixedPubKeyMixedRef":          testTwoContainersMixedPubKeyMixedRef,
 		"TwoContainersSingleWithInitPubKeyMixedRef": testTwoContainersWithInitSinglePubKeyMixedRef,
+		"EventEmittedOnSignatureVerification":       testEventEmittedOnSignatureVerification,
+		"EventEmittedOnNoSignatureVerification":     testEventEmittedOnNoSignatureVerification,
 	}
 
 	for name, tf := range testFuncs {
@@ -20,6 +23,7 @@ func TestPassingDeployments(t *testing.T) {
 	}
 }
 
+// TestFailingDeployments tests deployments that should fail signature verification
 func TestFailingDeployments(t *testing.T) {
 
 	testFuncs := map[string]func(t *testing.T){

--- a/test/webhook_test.go
+++ b/test/webhook_test.go
@@ -2,12 +2,11 @@ package test
 
 import (
 	"github.com/eumel8/cosignwebhook/test/framework"
-	"testing"
-
 	"github.com/eumel8/cosignwebhook/webhook"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
 )
 
 // terminationGracePeriodSeconds is the termination grace period for the test deployments
@@ -47,7 +46,7 @@ func testOneContainerSinglePubKeyEnvRef(t *testing.T) {
 							Command: []string{
 								"sh",
 								"-c",
-								"while true; do echo 'hello world, i am tired and will sleep now'; sleep 10; done",
+								"while true; do echo 'hello world, i am tired and will sleep now'; sleep 60; done",
 							},
 							Env: []corev1.EnvVar{
 								{
@@ -64,7 +63,7 @@ func testOneContainerSinglePubKeyEnvRef(t *testing.T) {
 
 	fw.CreateDeployment(t, depl)
 	fw.WaitForDeployment(t, depl)
-	fw.Cleanup(t, nil)
+	fw.Cleanup(t)
 }
 
 // testTwoContainersSinglePubKeyEnvRef tests that a deployment with two signed containers,
@@ -103,7 +102,7 @@ func testTwoContainersSinglePubKeyEnvRef(t *testing.T) {
 							Command: []string{
 								"sh",
 								"-c",
-								"while true; do echo 'hello world, i am tired and will sleep now'; sleep 10; done",
+								"while true; do echo 'hello world, i am tired and will sleep now'; sleep 60; done",
 							},
 							Env: []corev1.EnvVar{
 								{
@@ -118,7 +117,7 @@ func testTwoContainersSinglePubKeyEnvRef(t *testing.T) {
 							Command: []string{
 								"sh",
 								"-c",
-								"while true; do echo 'hello world, i am tired and will sleep now'; sleep 10; done",
+								"while true; do echo 'hello world, i am tired and will sleep now'; sleep 60; done",
 							},
 							Env: []corev1.EnvVar{
 								{
@@ -135,7 +134,7 @@ func testTwoContainersSinglePubKeyEnvRef(t *testing.T) {
 
 	fw.CreateDeployment(t, depl)
 	fw.WaitForDeployment(t, depl)
-	fw.Cleanup(t, nil)
+	fw.Cleanup(t)
 }
 
 // testOneContainerPubKeySecret tests that a deployment with a single signed container,
@@ -184,7 +183,7 @@ func testOneContainerSinglePubKeySecretRef(t *testing.T) {
 							Command: []string{
 								"sh",
 								"-c",
-								"while true; do echo 'hello world, i am tired and will sleep now'; sleep 10; done",
+								"while true; do echo 'hello world, i am tired and will sleep now'; sleep 60; done",
 							},
 							Env: []corev1.EnvVar{
 								{
@@ -209,7 +208,7 @@ func testOneContainerSinglePubKeySecretRef(t *testing.T) {
 	fw.CreateSecret(t, secret)
 	fw.CreateDeployment(t, depl)
 	fw.WaitForDeployment(t, depl)
-	fw.Cleanup(t, nil)
+	fw.Cleanup(t)
 }
 
 // testTwoContainersMixedPubKeyMixedRef tests that a deployment with two signed containers with two different public keys,
@@ -259,7 +258,7 @@ func testTwoContainersMixedPubKeyMixedRef(t *testing.T) {
 							Command: []string{
 								"sh",
 								"-c",
-								"while true; do echo 'hello world, i am tired and will sleep now'; sleep 10; done",
+								"while true; do echo 'hello world, i am tired and will sleep now'; sleep 60; done",
 							},
 							Env: []corev1.EnvVar{
 								{
@@ -281,7 +280,7 @@ func testTwoContainersMixedPubKeyMixedRef(t *testing.T) {
 							Command: []string{
 								"sh",
 								"-c",
-								"while true; do echo 'hello world, i am tired and will sleep now'; sleep 10; done",
+								"while true; do echo 'hello world, i am tired and will sleep now'; sleep 60; done",
 							},
 							Env: []corev1.EnvVar{
 								{
@@ -299,7 +298,7 @@ func testTwoContainersMixedPubKeyMixedRef(t *testing.T) {
 	fw.CreateSecret(t, secret)
 	fw.CreateDeployment(t, depl)
 	fw.WaitForDeployment(t, depl)
-	fw.Cleanup(t, nil)
+	fw.Cleanup(t)
 
 }
 
@@ -350,7 +349,7 @@ func testTwoContainersSinglePubKeyMixedRef(t *testing.T) {
 							Command: []string{
 								"sh",
 								"-c",
-								"while true; do echo 'hello world, i am tired and will sleep now'; sleep 10; done",
+								"while true; do echo 'hello world, i am tired and will sleep now'; sleep 60; done",
 							},
 							Env: []corev1.EnvVar{
 								{
@@ -372,7 +371,7 @@ func testTwoContainersSinglePubKeyMixedRef(t *testing.T) {
 							Command: []string{
 								"sh",
 								"-c",
-								"while true; do echo 'hello world, i am tired and will sleep now'; sleep 10; done",
+								"while true; do echo 'hello world, i am tired and will sleep now'; sleep 60; done",
 							},
 							Env: []corev1.EnvVar{
 								{
@@ -390,7 +389,7 @@ func testTwoContainersSinglePubKeyMixedRef(t *testing.T) {
 	fw.CreateSecret(t, secret)
 	fw.CreateDeployment(t, depl)
 	fw.WaitForDeployment(t, depl)
-	fw.Cleanup(t, nil)
+	fw.Cleanup(t)
 
 }
 
@@ -465,7 +464,7 @@ func testTwoContainersWithInitSinglePubKeyMixedRef(t *testing.T) {
 							Command: []string{
 								"sh",
 								"-c",
-								"while true; do echo 'hello world, i am tired and will sleep now'; sleep 10; done",
+								"while true; do echo 'hello world, i am tired and will sleep now'; sleep 60; done",
 							},
 							Env: []corev1.EnvVar{
 								{
@@ -483,7 +482,104 @@ func testTwoContainersWithInitSinglePubKeyMixedRef(t *testing.T) {
 	fw.CreateSecret(t, secret)
 	fw.CreateDeployment(t, depl)
 	fw.WaitForDeployment(t, depl)
-	fw.Cleanup(t, nil)
+	fw.Cleanup(t)
+}
+
+// testEventEmittedOnSignatureVerification tests
+// that an event is emitted when a deployment passes signature verification
+func testEventEmittedOnSignatureVerification(t *testing.T) {
+	fw, err := framework.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, pub := fw.CreateKeys(t, "test")
+	fw.SignContainer(t, "test", "k3d-registry.localhost:5000/busybox:first")
+
+	// create a deployment with a single signed container and a public key provided via an environment variable
+	depl := appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-case-7",
+			Namespace: "test-cases",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test-case-7"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "test-case-7"},
+				},
+				Spec: corev1.PodSpec{
+					TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
+					Containers: []corev1.Container{
+						{
+							Name:  "test-case-7",
+							Image: "k3d-registry.localhost:5000/busybox:first",
+							Command: []string{
+								"sh",
+								"-c",
+								"echo 'hello world, i am tired and will sleep now, for a bit...'; sleep 60",
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name:  webhook.CosignEnvVar,
+									Value: pub,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fw.CreateDeployment(t, depl)
+	fw.WaitForDeployment(t, depl)
+	pod := fw.GetPods(t, depl)
+	fw.AssertEventForPod(t, "PodVerified", pod.Items[0])
+	fw.Cleanup(t)
+}
+
+func testEventEmittedOnNoSignatureVerification(t *testing.T) {
+	fw, err := framework.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create a deployment with a single unsigned container
+	depl := appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-case-8",
+			Namespace: "test-cases",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test-case-8"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "test-case-8"},
+				},
+				Spec: corev1.PodSpec{
+					TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
+					Containers: []corev1.Container{
+						{
+							Name:    "test-case-8",
+							Image:   "k3d-registry.localhost:5000/busybox:first",
+							Command: []string{"sh", "-c", "echo 'hello world, i am tired and will sleep now, for a bit...'; sleep 60"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fw.CreateDeployment(t, depl)
+	fw.WaitForDeployment(t, depl)
+	pl := fw.GetPods(t, depl)
+	fw.AssertEventForPod(t, "NoVerification", pl.Items[0])
+	fw.Cleanup(t)
 }
 
 // testOneContainerSinglePubKeyNoMatchEnvRef tests that a deployment with a single signed container,
@@ -522,7 +618,7 @@ func testOneContainerSinglePubKeyNoMatchEnvRef(t *testing.T) {
 							Command: []string{
 								"sh",
 								"-c",
-								"while true; do echo 'hello world, i am tired and will sleep now'; sleep 10; done",
+								"while true; do echo 'hello world, i am tired and will sleep now'; sleep 60; done",
 							},
 							Env: []corev1.EnvVar{
 								{
@@ -539,7 +635,7 @@ func testOneContainerSinglePubKeyNoMatchEnvRef(t *testing.T) {
 
 	fw.CreateDeployment(t, depl)
 	fw.AssertDeploymentFailed(t, depl)
-	fw.Cleanup(t, nil)
+	fw.Cleanup(t)
 
 }
 
@@ -578,7 +674,7 @@ func testTwoContainersSinglePubKeyMalformedEnvRef(t *testing.T) {
 							Command: []string{
 								"sh",
 								"-c",
-								"while true; do echo 'hello world, i am tired and will sleep now'; sleep 10; done",
+								"while true; do echo 'hello world, i am tired and will sleep now'; sleep 60; done",
 							},
 							Env: []corev1.EnvVar{
 								{
@@ -593,7 +689,7 @@ func testTwoContainersSinglePubKeyMalformedEnvRef(t *testing.T) {
 							Command: []string{
 								"sh",
 								"-c",
-								"while true; do echo 'hello world, i am tired and will sleep now'; sleep 10; done",
+								"while true; do echo 'hello world, i am tired and will sleep now'; sleep 60; done",
 							},
 							Env: []corev1.EnvVar{
 								{
@@ -610,7 +706,7 @@ func testTwoContainersSinglePubKeyMalformedEnvRef(t *testing.T) {
 
 	fw.CreateDeployment(t, depl)
 	fw.AssertDeploymentFailed(t, depl)
-	fw.Cleanup(t, nil)
+	fw.Cleanup(t)
 
 }
 
@@ -644,7 +740,7 @@ func testOneContainerSinglePubKeyMalformedEnvRef(t *testing.T) {
 							Command: []string{
 								"sh",
 								"-c",
-								"while true; do echo 'hello world, i am tired and will sleep now'; sleep 10; done",
+								"while true; do echo 'hello world, i am tired and will sleep now'; sleep 60; done",
 							},
 							Env: []corev1.EnvVar{
 								{
@@ -661,6 +757,6 @@ func testOneContainerSinglePubKeyMalformedEnvRef(t *testing.T) {
 
 	fw.CreateDeployment(t, depl)
 	fw.AssertDeploymentFailed(t, depl)
-	fw.Cleanup(t, nil)
+	fw.Cleanup(t)
 
 }


### PR DESCRIPTION
## Motivation

Addresses #30 

## Changes

- Moved the EventBroadcaster to the cosign webhook server struct, as there was no need to explicitly create a new instance each time an event should be transmitted
- Added a new "Event" (a string really), to indicate that no verification was done
- Added a new function to search for the public key to be used for verification - if no key is found, no verification can be done → emit the new 
- Added 2 new E2E tests to test the event emission 
- Cleanup on repository
- Some new `make` targets for E2E and doc update

## Tests

E2E tests, which were manually observed as well :)