### PR TITLE
Updates example "Public key as secret reference" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ kind: Secret
 data:
   COSIGNPUBKEY: LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFS1BhWUhnZEVEQ3ltcGx5emlIdkJ5UjNxRkhZdgppaWxlMCtFMEtzVzFqWkhJa1p4UWN3aGsySjNqSm5VdTdmcjcrd05DeENkVEdYQmhBSTJveE1LbWx3PT0KLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0t
 metadata:
-  name: cosignwebhook
+  name: cosign_secret # Can be choosen freely
 type: Opaque
 ```
 
@@ -91,7 +91,7 @@ type: Opaque
           - name: COSIGNPUBKEY
             valueFrom:
               secretKeyRef:
-                name: cosignwebhook
+                name: cosign_secret # Must be equal to metadata.name of the secrect
                 key: COSIGNPUBKEY
 ```
 


### PR DESCRIPTION
Updates the code example in section "Public key as secret reference" to prevent that a default secret for the namespace is generated.