### PR TITLE
Refactor E2E test suite + add RSA tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PORT := 5000
 .PHONY: test-e2e
 test-e2e:
 	@echo "Running e2e tests..."
-	@go test -v -race -count 1 ./test/
+	@export COSIGN_E2E="42" && go test -v -race -count 1 ./test/
 
 .PHONY: test-unit
 test-unit:

--- a/test/framework/client.go
+++ b/test/framework/client.go
@@ -18,9 +18,16 @@ import (
 // the cosignwebhook in a k8s cluster
 type Framework struct {
 	k8s *kubernetes.Clientset
+	t   *testing.T
+	err error
 }
 
-func New() (*Framework, error) {
+// New creates a new Framework
+func New(t *testing.T) (*Framework, error) {
+	if t == nil {
+		return nil, fmt.Errorf("test object must not be nil")
+	}
+
 	k8s, err := createClientSet()
 	if err != nil {
 		return nil, err
@@ -28,6 +35,7 @@ func New() (*Framework, error) {
 
 	return &Framework{
 		k8s: k8s,
+		t:   t,
 	}, nil
 }
 
@@ -37,7 +45,6 @@ func createClientSet() (k8sClient *kubernetes.Clientset, err error) {
 		kubeconfig = os.Getenv("HOME") + "/.kube/config"
 	}
 
-	// create restconfig from kubeconfig
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
 		return nil, err
@@ -52,31 +59,33 @@ func createClientSet() (k8sClient *kubernetes.Clientset, err error) {
 
 // Cleanup removes all resources created by the framework
 // and cleans up the testing directory.
-func (f *Framework) Cleanup(t testing.TB) {
-	cleanupKeys(t)
-	f.cleanupDeployments(t)
-	f.cleanupSecrets(t)
+func (f *Framework) Cleanup() {
+	f.cleanupKeys()
+	f.cleanupDeployments()
+	f.cleanupSecrets()
+	if f.err != nil {
+		f.t.Fatal(f.err)
+	}
 }
 
 // cleanupDeployments removes all deployments from the testing namespace
 // if they exist
-func (f *Framework) cleanupDeployments(t testing.TB) {
+func (f *Framework) cleanupDeployments() {
 	if f.k8s == nil {
-		t.Logf("k8s client is nil")
 		return
 	}
 
-	t.Logf("cleaning up deployments")
+	f.t.Logf("cleaning up deployments")
 	deployments, err := f.k8s.AppsV1().Deployments("test-cases").List(context.Background(), metav1.ListOptions{})
 	if err != nil {
-		f.Cleanup(t)
-		t.Fatal(err)
+		f.err = err
+		return
 	}
 	for _, d := range deployments.Items {
 		err = f.k8s.AppsV1().Deployments("test-cases").Delete(context.Background(), d.Name, metav1.DeleteOptions{})
 		if err != nil {
-			f.Cleanup(t)
-			t.Fatal(err)
+			f.err = err
+			return
 		}
 	}
 
@@ -84,16 +93,16 @@ func (f *Framework) cleanupDeployments(t testing.TB) {
 	for {
 		select {
 		case <-timeout:
-			f.Cleanup(t)
+			f.err = fmt.Errorf("timeout reached while waiting for deployments to be deleted")
 		default:
 			pods, err := f.k8s.CoreV1().Pods("test-cases").List(context.Background(), metav1.ListOptions{})
 			if err != nil {
-				f.Cleanup(t)
-				t.Fatal(err)
+				f.err = err
+				return
 			}
 
 			if len(pods.Items) == 0 {
-				t.Logf("All pods are deleted")
+				f.t.Logf("All pods are deleted")
 				return
 			}
 			time.Sleep(5 * time.Second)
@@ -102,66 +111,84 @@ func (f *Framework) cleanupDeployments(t testing.TB) {
 }
 
 // cleanupSecrets removes all secrets from the testing namespace
-func (f *Framework) cleanupSecrets(t testing.TB) {
+func (f *Framework) cleanupSecrets() {
 	if f.k8s == nil {
-		t.Logf("k8s client is nil")
 		return
 	}
 
-	t.Logf("cleaning up secrets")
+	f.t.Logf("cleaning up secrets")
 	secrets, err := f.k8s.CoreV1().Secrets("test-cases").List(context.Background(), metav1.ListOptions{})
 	if err != nil {
-		f.Cleanup(t)
-		t.Fatal(err)
+		f.err = err
+		return
 	}
 	if len(secrets.Items) == 0 {
+		f.t.Log("no secrets to delete")
 		return
 	}
 	for _, s := range secrets.Items {
 		err = f.k8s.CoreV1().Secrets("test-cases").Delete(context.Background(), s.Name, metav1.DeleteOptions{})
 		if err != nil {
-			f.Cleanup(t)
-			t.Fatal(err)
+			f.err = err
+			return
 		}
 	}
+	f.t.Log("all secrets are deleted")
 }
 
 // GetPods returns the pod(s) of the deployment. The fetch is done by label selector (app=<deployment name>)
 // If the get request fails, the test will fail and the framework will be cleaned up
-func (f *Framework) GetPods(t *testing.T, d appsv1.Deployment) *corev1.PodList {
+func (f *Framework) GetPods(d appsv1.Deployment) *corev1.PodList {
+	if f.err != nil {
+		return nil
+	}
+
 	pods, err := f.k8s.CoreV1().Pods("test-cases").List(context.Background(), metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("app=%s", d.Name),
 	})
 	if err != nil {
-		f.Cleanup(t)
-		t.Fatal(err)
+		f.err = err
 	}
 	return pods
 }
 
 // CreateDeployment creates a deployment in the testing namespace
-func (f *Framework) CreateDeployment(t testing.TB, d appsv1.Deployment) {
+func (f *Framework) CreateDeployment(d appsv1.Deployment) {
+	if f.err != nil {
+		return
+	}
+
+	f.t.Logf("creating deployment %s", d.Name)
 	_, err := f.k8s.AppsV1().Deployments("test-cases").Create(context.Background(), &d, metav1.CreateOptions{})
 	if err != nil {
-		f.Cleanup(t)
-		t.Fatal(err)
+		f.err = err
+		return
 	}
+	f.t.Logf("deployment %s created", d.Name)
 }
 
 // CreateSecret creates a secret in the testing namespace
-func (f *Framework) CreateSecret(t *testing.T, secret corev1.Secret) {
-	t.Logf("creating secret %s", secret.Name)
-	s, err := f.k8s.CoreV1().Secrets("test-cases").Create(context.Background(), &secret, metav1.CreateOptions{})
-	if err != nil {
-		f.Cleanup(t)
-		t.Fatal(err)
+func (f *Framework) CreateSecret(secret corev1.Secret) {
+	if f.err != nil {
+		return
 	}
-	t.Logf("created secret %s", s.Name)
+
+	f.t.Logf("creating secret %s", secret.Name)
+	_, err := f.k8s.CoreV1().Secrets("test-cases").Create(context.Background(), &secret, metav1.CreateOptions{})
+	if err != nil {
+		f.err = err
+		return
+	}
+	f.t.Logf("secret %s created", secret.Name)
 }
 
 // WaitForDeployment waits until the deployment is ready
-func (f *Framework) WaitForDeployment(t *testing.T, d appsv1.Deployment) {
-	t.Logf("waiting for deployment %s to be ready", d.Name)
+func (f *Framework) WaitForDeployment(d appsv1.Deployment) {
+	if f.err != nil {
+		return
+	}
+
+	f.t.Logf("waiting for deployment %s to be ready", d.Name)
 	// wait until the deployment is ready
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -169,15 +196,14 @@ func (f *Framework) WaitForDeployment(t *testing.T, d appsv1.Deployment) {
 		FieldSelector: fmt.Sprintf("metadata.name=%s", d.Name),
 	})
 	if err != nil {
-		f.Cleanup(t)
-		t.Fatal(err)
+		f.err = err
+		return
 	}
 
 	for {
 		select {
 		case <-ctx.Done():
-			f.Cleanup(t)
-			t.Fatal("timeout reached while waiting for deployment to be ready")
+			f.err = fmt.Errorf("timeout reached while waiting for deployment to be ready")
 		case event := <-w.ResultChan():
 			deployment, ok := event.Object.(*appsv1.Deployment)
 			if !ok {
@@ -186,7 +212,7 @@ func (f *Framework) WaitForDeployment(t *testing.T, d appsv1.Deployment) {
 			}
 
 			if deployment.Status.ReadyReplicas == 1 {
-				t.Logf("deployment %s is ready", d.Name)
+				f.t.Logf("deployment %s is ready", d.Name)
 				return
 			}
 			time.Sleep(5 * time.Second)
@@ -195,13 +221,17 @@ func (f *Framework) WaitForDeployment(t *testing.T, d appsv1.Deployment) {
 }
 
 // waitForReplicaSetCreation waits for the replicaset of the given deployment to be created
-func (f *Framework) waitForReplicaSetCreation(t *testing.T, d appsv1.Deployment) (string, error) {
+func (f *Framework) waitForReplicaSetCreation(d appsv1.Deployment) string {
+	if f.err != nil {
+		return ""
+	}
+
 	rs, err := f.k8s.AppsV1().ReplicaSets("test-cases").Watch(context.Background(), metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("app=%s", d.Name),
 	})
 	if err != nil {
-		f.Cleanup(t)
-		t.Fatal(err)
+		f.err = err
+		return ""
 	}
 
 	ctx, done := context.WithTimeout(context.Background(), 30*time.Second)
@@ -210,13 +240,12 @@ func (f *Framework) waitForReplicaSetCreation(t *testing.T, d appsv1.Deployment)
 	for {
 		select {
 		case <-ctx.Done():
-			f.Cleanup(t)
-			t.Fatal("timeout reached while waiting for replicaset to be created")
+			f.err = fmt.Errorf("timeout reached while waiting for replicaset to be created")
 		case event := <-rs.ResultChan():
 			rs, ok := event.Object.(*appsv1.ReplicaSet)
 			if ok {
-				t.Logf("replicaset %s created", rs.Name)
-				return rs.Name, nil
+				f.t.Logf("replicaset %s created", rs.Name)
+				return rs.Name
 			}
 			time.Sleep(5 * time.Second)
 		}
@@ -224,14 +253,17 @@ func (f *Framework) waitForReplicaSetCreation(t *testing.T, d appsv1.Deployment)
 }
 
 // AssertDeploymentFailed asserts that the deployment cannot start
-func (f *Framework) AssertDeploymentFailed(t *testing.T, d appsv1.Deployment) {
-	t.Logf("waiting for deployment %s to fail", d.Name)
+func (f *Framework) AssertDeploymentFailed(d appsv1.Deployment) {
+	if f.err != nil {
+		return
+	}
+
+	f.t.Logf("waiting for deployment %s to fail", d.Name)
 
 	// watch for replicasets of the deployment
-	rsName, err := f.waitForReplicaSetCreation(t, d)
-	if err != nil {
-		f.Cleanup(t)
-		t.Fatal(err)
+	rsName := f.waitForReplicaSetCreation(d)
+	if rsName == "" {
+		return
 	}
 
 	// get warning events of deployment's namespace and check if the deployment failed
@@ -239,8 +271,8 @@ func (f *Framework) AssertDeploymentFailed(t *testing.T, d appsv1.Deployment) {
 		FieldSelector: fmt.Sprintf("involvedObject.name=%s", rsName),
 	})
 	if err != nil {
-		f.Cleanup(t)
-		t.Fatal(err)
+		f.err = err
+		return
 	}
 
 	ctx, done := context.WithTimeout(context.Background(), 30*time.Second)
@@ -249,8 +281,7 @@ func (f *Framework) AssertDeploymentFailed(t *testing.T, d appsv1.Deployment) {
 	for {
 		select {
 		case <-ctx.Done():
-			f.Cleanup(t)
-			t.Fatal("timeout reached while waiting for deployment to fail")
+			f.err = fmt.Errorf("timeout reached while waiting for deployment to fail")
 		case event := <-w.ResultChan():
 			e, ok := event.Object.(*corev1.Event)
 			if !ok {
@@ -258,7 +289,7 @@ func (f *Framework) AssertDeploymentFailed(t *testing.T, d appsv1.Deployment) {
 				continue
 			}
 			if e.Reason == "FailedCreate" {
-				t.Logf("deployment %s failed: %s", d.Name, e.Message)
+				f.t.Logf("deployment %s failed: %s", d.Name, e.Message)
 				return
 			}
 			time.Sleep(5 * time.Second)
@@ -267,16 +298,20 @@ func (f *Framework) AssertDeploymentFailed(t *testing.T, d appsv1.Deployment) {
 }
 
 // AssertEventForPod asserts that a PodVerified event is created
-func (f *Framework) AssertEventForPod(t *testing.T, reason string, p corev1.Pod) {
-	t.Logf("waiting for %s event to be created for pod %s", reason, p.Name)
+func (f *Framework) AssertEventForPod(reason string, p corev1.Pod) {
+	if f.err != nil {
+		return
+	}
+
+	f.t.Logf("waiting for %s event to be created for pod %s", reason, p.Name)
 
 	// watch for events of deployment's namespace and check if the podverified event is created
 	w, err := f.k8s.CoreV1().Events("test-cases").Watch(context.Background(), metav1.ListOptions{
 		FieldSelector: fmt.Sprintf("involvedObject.name=%s", p.Name),
 	})
 	if err != nil {
-		f.Cleanup(t)
-		t.Fatal(err)
+		f.err = err
+		return
 	}
 
 	ctx, done := context.WithTimeout(context.Background(), 30*time.Second)
@@ -285,8 +320,7 @@ func (f *Framework) AssertEventForPod(t *testing.T, reason string, p corev1.Pod)
 	for {
 		select {
 		case <-ctx.Done():
-			f.Cleanup(t)
-			t.Fatal("timeout reached while waiting for podverified event")
+			f.err = fmt.Errorf("timeout reached while waiting for event to be created")
 		case event := <-w.ResultChan():
 			e, ok := event.Object.(*corev1.Event)
 			if !ok {
@@ -294,7 +328,7 @@ func (f *Framework) AssertEventForPod(t *testing.T, reason string, p corev1.Pod)
 				continue
 			}
 			if e.Reason == reason {
-				t.Logf("%s event created for pod %s", reason, p.Name)
+				f.t.Logf("%s event created for pod %s", reason, p.Name)
 				return
 			}
 			time.Sleep(5 * time.Second)

--- a/test/framework/cosign.go
+++ b/test/framework/cosign.go
@@ -69,7 +69,6 @@ func (f *Framework) cleanupKeys() {
 
 // CreateECDSAKeyPair generates an ECDSA keypair and saves the keys to the current directory
 func CreateECDSAKeyPair(f *Framework, name string) (Priv, Pub) {
-
 	if f.err != nil {
 		return Priv{}, Pub{}
 	}
@@ -111,7 +110,6 @@ func CreateECDSAKeyPair(f *Framework, name string) (Priv, Pub) {
 
 // CreateRSAKeyPair generates an RSA keypair and saves the keys to the current directory
 func CreateRSAKeyPair(f *Framework, name string) (Priv, Pub) {
-
 	if f.err != nil {
 		return Priv{}, Pub{}
 	}
@@ -185,7 +183,6 @@ func CreateRSAKeyPair(f *Framework, name string) (Priv, Pub) {
 
 // SignContainer signs the container using the provided SignOptions
 func (f *Framework) SignContainer(opts SignOptions) {
-
 	if f.err != nil {
 		return
 	}

--- a/test/framework/cosign.go
+++ b/test/framework/cosign.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"testing"
 	"time"
 
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/importkeypair"
@@ -21,140 +20,16 @@ import (
 
 const ImportKeySuffix = "imported"
 
-// cleanupKeys removes all keypair files from the testing directory
-func cleanupKeys(t testing.TB) {
-	t.Logf("cleaning up keypair files")
-	files, err := os.ReadDir(".")
-	if err != nil {
-		t.Fatalf("failed reading directory: %v", err)
-	}
-	for _, f := range files {
-		if f.IsDir() {
-			continue
-		}
-		reKey := regexp.MustCompile(".*.key")
-		rePub := regexp.MustCompile(".*.pub")
-		if reKey.MatchString(f.Name()) || rePub.MatchString(f.Name()) {
-			err = os.Remove(f.Name())
-			if err != nil {
-				t.Fatalf("failed removing file %s: %v", f.Name(), err)
-			}
-		}
-	}
-	t.Logf("cleaned up keypair files")
-}
-
-type pub struct {
+// Pub contains the public key and its path
+type Pub struct {
 	Key  string
 	Path string
 }
 
-type priv struct {
+// Priv contains the private key and its path
+type Priv struct {
 	Key  string
 	Path string
-}
-
-// CreateKeys creates a signing keypair for cosing with the provided name
-func (f *Framework) CreateKeys(t testing.TB, name string) (priv, pub) {
-	args := []string{fmt.Sprintf("--output-key-prefix=%s", name)}
-	err := os.Setenv("COSIGN_PASSWORD", "")
-	if err != nil {
-		t.Fatalf("failed setting COSIGN_PASSWORD: %v", err)
-	}
-	cmd := cli.GenerateKeyPair()
-	cmd.SetArgs(args)
-	err = cmd.Execute()
-	if err != nil {
-		f.Cleanup(t)
-	}
-
-	// read private key and public key from the current directory
-	privateKey, err := os.ReadFile(fmt.Sprintf("%s.key", name))
-	if err != nil {
-		f.Cleanup(t)
-	}
-	pubKey, err := os.ReadFile(fmt.Sprintf("%s.pub", name))
-	if err != nil {
-		f.Cleanup(t)
-	}
-
-	return priv{
-			Key:  string(privateKey),
-			Path: fmt.Sprintf("%s.key", name),
-		}, pub{
-			Key:  string(pubKey),
-			Path: fmt.Sprintf("%s.pub", name),
-		}
-}
-
-// CreateRSAKeyPair creates an RSA keypair for signing with the provided name
-func (f *Framework) CreateRSAKeyPair(t *testing.T, name string) (priv, pub) {
-	pkey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		f.Cleanup(t)
-		t.Fatal(err)
-	}
-
-	privBytes := pem.EncodeToMemory(&pem.Block{
-		Type:  "RSA PRIVATE KEY",
-		Bytes: x509.MarshalPKCS1PrivateKey(pkey),
-	})
-
-	err = os.WriteFile(fmt.Sprintf("%s.key", name), privBytes, 0o644)
-	if err != nil {
-		t.Errorf("failed to write private key to file: %v", err)
-		return priv{}, pub{}
-	}
-
-	// Generate and save the public key to a PEM file
-	pubKey := &pkey.PublicKey
-
-	pubASN1, err := x509.MarshalPKIXPublicKey(pubKey)
-	if err != nil {
-		f.Cleanup(t)
-		t.Fatal(err)
-	}
-	pubBytes := pem.EncodeToMemory(&pem.Block{
-		Type:  "PUBLIC KEY",
-		Bytes: pubASN1,
-	})
-	err = os.WriteFile(fmt.Sprintf("%s.pub", name), pubBytes, 0o644)
-	if err != nil {
-		t.Errorf("failed to write public key to file: %v", err)
-		return priv{}, pub{}
-	}
-
-	t.Setenv("COSIGN_PASSWORD", "")
-	// import the keypair into cosign for signing
-	err = importkeypair.ImportKeyPairCmd(context.Background(), options.ImportKeyPairOptions{
-		Key:             fmt.Sprintf("%s.key", name),
-		OutputKeyPrefix: fmt.Sprintf("%s-%s", name, ImportKeySuffix),
-	}, []string{})
-	if err != nil {
-		t.Errorf("failed to import keypair to cosign: %v", err)
-		return priv{}, pub{}
-	}
-
-	// read private key and public key from the current directory
-	privBytes, err = os.ReadFile(fmt.Sprintf("%s-%s.key", name, ImportKeySuffix))
-	if err != nil {
-		f.Cleanup(t)
-		t.Fatal(err)
-	}
-
-	pubBytes, err = os.ReadFile(fmt.Sprintf("%s-%s.pub", name, ImportKeySuffix))
-	if err != nil {
-		f.Cleanup(t)
-		t.Fatal(err)
-	}
-
-	return priv{
-			Key:  string(privBytes),
-			Path: fmt.Sprintf("%s-%s.key", name, ImportKeySuffix),
-		}, pub{
-			Key:  string(pubBytes),
-			Path: fmt.Sprintf("%s-%s.pub", name, ImportKeySuffix),
-		}
 }
 
 // SignOptions is a struct to hold the options for signing a container
@@ -164,15 +39,164 @@ type SignOptions struct {
 	SignatureRepo string
 }
 
-// SignContainer signs the container with the provided private key
-func (f *Framework) SignContainer(t *testing.T, opts SignOptions) {
+// KeyFunc is a function that generates a keypair by using the testing framework
+type KeyFunc func(f *Framework, name string) (Priv, Pub)
+
+// cleanupKeys removes all keypair files from the testing directory
+func (f *Framework) cleanupKeys() {
+	f.t.Logf("cleaning up keypair files")
+	files, err := os.ReadDir(".")
+	if err != nil {
+		f.err = fmt.Errorf("failed reading directory: %v", err)
+		return
+	}
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+		reKey := regexp.MustCompile(".*.key")
+		rePub := regexp.MustCompile(".*.pub")
+		if reKey.MatchString(file.Name()) || rePub.MatchString(file.Name()) {
+			err = os.Remove(file.Name())
+			if err != nil {
+				f.err = fmt.Errorf("failed to remove file: %v", err)
+				return
+			}
+		}
+	}
+	f.t.Logf("cleaned up keypair files")
+}
+
+// CreateECDSAKeyPair generates an ECDSA keypair and saves the keys to the current directory
+func CreateECDSAKeyPair(f *Framework, name string) (Priv, Pub) {
+
+	if f.err != nil {
+		return Priv{}, Pub{}
+	}
+
+	args := []string{fmt.Sprintf("--output-key-prefix=%s", name)}
+	err := os.Setenv("COSIGN_PASSWORD", "")
+	if err != nil {
+		f.err = err
+		return Priv{}, Pub{}
+	}
+	cmd := cli.GenerateKeyPair()
+	cmd.SetArgs(args)
+	err = cmd.Execute()
+	if err != nil {
+		f.err = err
+		return Priv{}, Pub{}
+	}
+
+	// read private key and public key from the current directory
+	privateKey, err := os.ReadFile(fmt.Sprintf("%s.key", name))
+	if err != nil {
+		f.err = err
+		return Priv{}, Pub{}
+	}
+	pubKey, err := os.ReadFile(fmt.Sprintf("%s.pub", name))
+	if err != nil {
+		f.err = err
+		return Priv{}, Pub{}
+	}
+
+	return Priv{
+			Key:  string(privateKey),
+			Path: fmt.Sprintf("%s.key", name),
+		}, Pub{
+			Key:  string(pubKey),
+			Path: fmt.Sprintf("%s.pub", name),
+		}
+}
+
+// CreateRSAKeyPair generates an RSA keypair and saves the keys to the current directory
+func CreateRSAKeyPair(f *Framework, name string) (Priv, Pub) {
+
+	if f.err != nil {
+		return Priv{}, Pub{}
+	}
+
+	pkey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		f.err = fmt.Errorf("failed to generate RSA key: %v", err)
+		return Priv{}, Pub{}
+	}
+	privBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(pkey),
+	})
+
+	err = os.WriteFile(fmt.Sprintf("%s.key", name), privBytes, 0o644)
+	if err != nil {
+		f.err = fmt.Errorf("failed to write private key to file: %v", err)
+		return Priv{}, Pub{}
+	}
+
+	// Generate and save the public key to a PEM file
+	pubKey := &pkey.PublicKey
+
+	pubASN1, err := x509.MarshalPKIXPublicKey(pubKey)
+	if err != nil {
+		f.err = fmt.Errorf("failed to marshal public key: %v", err)
+		return Priv{}, Pub{}
+	}
+	pubBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: pubASN1,
+	})
+	err = os.WriteFile(fmt.Sprintf("%s.pub", name), pubBytes, 0o644)
+	if err != nil {
+		f.err = fmt.Errorf("failed to write public key to file: %v", err)
+		return Priv{}, Pub{}
+	}
+
+	f.t.Setenv("COSIGN_PASSWORD", "")
+	// import the keypair into cosign for signing
+	err = importkeypair.ImportKeyPairCmd(context.Background(), options.ImportKeyPairOptions{
+		Key:             fmt.Sprintf("%s.key", name),
+		OutputKeyPrefix: fmt.Sprintf("%s-%s", name, ImportKeySuffix),
+	}, []string{})
+	if err != nil {
+		f.err = fmt.Errorf("failed to import keypair: %v", err)
+		return Priv{}, Pub{}
+	}
+
+	// read private key and public key from the current directory
+	privBytes, err = os.ReadFile(fmt.Sprintf("%s-%s.key", name, ImportKeySuffix))
+	if err != nil {
+		f.err = fmt.Errorf("failed reading private key: %v", err)
+		return Priv{}, Pub{}
+	}
+
+	pubBytes, err = os.ReadFile(fmt.Sprintf("%s-%s.pub", name, ImportKeySuffix))
+	if err != nil {
+		f.err = fmt.Errorf("failed reading public key: %v", err)
+		return Priv{}, Pub{}
+	}
+
+	return Priv{
+			Key:  string(privBytes),
+			Path: fmt.Sprintf("%s-%s.key", name, ImportKeySuffix),
+		}, Pub{
+			Key:  string(pubBytes),
+			Path: fmt.Sprintf("%s-%s.pub", name, ImportKeySuffix),
+		}
+}
+
+// SignContainer signs the container using the provided SignOptions
+func (f *Framework) SignContainer(opts SignOptions) {
+
+	if f.err != nil {
+		return
+	}
+
 	// get SHA of the container image
-	t.Setenv("COSIGN_PASSWORD", "")
+	f.t.Setenv("COSIGN_PASSWORD", "")
 
 	// if the signature repository is different from the image, set the COSIGN_REPOSITORY environment variable
 	// to push the signature to the specified repository
 	if opts.SignatureRepo != opts.Image {
-		t.Setenv("COSIGN_REPOSITORY", opts.SignatureRepo)
+		f.t.Setenv("COSIGN_REPOSITORY", opts.SignatureRepo)
 	}
 	err := sign.SignCmd(
 		&options.RootOptions{
@@ -189,7 +213,6 @@ func (f *Framework) SignContainer(t *testing.T, opts SignOptions) {
 		[]string{opts.Image},
 	)
 	if err != nil {
-		f.Cleanup(t)
-		t.Fatal(err)
+		f.err = fmt.Errorf("failed to sign container: %v", err)
 	}
 }

--- a/test/framework/cosign_test.go
+++ b/test/framework/cosign_test.go
@@ -17,10 +17,10 @@ func TestFramework_CreateRSAKeyPair(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := &Framework{}
-			priv, pub := f.CreateRSAKeyPair(t, tt.name)
+			private, public := f.CreateRSAKeyPair(t, tt.name)
 			defer f.Cleanup(t)
 
-			if priv == "" || pub == "" {
+			if private.Key == "" || public.Key == "" {
 				t.Fatal("failed to create RSA key pair")
 			}
 
@@ -69,9 +69,9 @@ func TestFramework_SignContainer_RSA(t *testing.T) {
 
 	f := &Framework{}
 	name := "testkey"
-	priv, pub := f.CreateRSAKeyPair(t, name)
+	private, public := f.CreateRSAKeyPair(t, name)
 	defer f.Cleanup(t)
-	if priv == "" || pub == "" {
+	if private.Key == "" || public.Key == "" {
 		t.Fatal("failed to create RSA key pair")
 	}
 

--- a/test/framework/cosign_test.go
+++ b/test/framework/cosign_test.go
@@ -16,9 +16,11 @@ func TestFramework_CreateRSAKeyPair(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := &Framework{}
-			private, public := f.CreateRSAKeyPair(t, tt.name)
-			defer f.Cleanup(t)
+			f := &Framework{
+				t: t,
+			}
+			defer f.Cleanup()
+			private, public := CreateRSAKeyPair(f, tt.name)
 
 			if private.Key == "" || public.Key == "" {
 				t.Fatal("failed to create RSA key pair")
@@ -67,10 +69,12 @@ func TestFramework_SignContainer_RSA(t *testing.T) {
 		t.Skip()
 	}
 
-	f := &Framework{}
+	f := &Framework{
+		t: t,
+	}
+	defer f.Cleanup()
 	name := "testkey"
-	private, public := f.CreateRSAKeyPair(t, name)
-	defer f.Cleanup(t)
+	private, public := CreateRSAKeyPair(f, name)
 	if private.Key == "" || public.Key == "" {
 		t.Fatal("failed to create RSA key pair")
 	}
@@ -84,7 +88,7 @@ func TestFramework_SignContainer_RSA(t *testing.T) {
 		t.Fatal("failed to create public key")
 	}
 
-	f.SignContainer(t, SignOptions{
+	f.SignContainer(SignOptions{
 		KeyPath: fmt.Sprintf("%s-%s.key", name, ImportKeySuffix),
 		Image:   "k3d-registry.localhost:5000/busybox:first",
 	})

--- a/test/main_test.go
+++ b/test/main_test.go
@@ -2,12 +2,14 @@ package test
 
 import (
 	"testing"
+
+	"github.com/eumel8/cosignwebhook/test/framework"
 )
 
-// TestPassingDeployments tests deployments that should pass signature verification
-func TestPassingDeployments(t *testing.T) {
-	testFuncs := map[string]func(t *testing.T){
-		"OneContainerSinglePubKeyEnvRef":            testOneContainerSinglePubKeyEnvRef,
+// TestPassECDSA tests deployments that should pass signature verification
+func TestPassECDSA(t *testing.T) {
+	testFuncs := map[string]func(fw *framework.Framework, kf framework.KeyFunc, key string) func(t *testing.T){
+		"OneContainerSinglePubKeyEnvRef":            oneContainerSinglePubKeyEnvRef,
 		"TwoContainersSinglePubKeyEnvRef":           testTwoContainersSinglePubKeyEnvRef,
 		"OneContainerSinglePubKeySecretRef":         testOneContainerSinglePubKeySecretRef,
 		"TwoContainersSinglePubKeyMixedRef":         testTwoContainersSinglePubKeyMixedRef,
@@ -16,25 +18,33 @@ func TestPassingDeployments(t *testing.T) {
 		"EventEmittedOnSignatureVerification":       testEventEmittedOnSignatureVerification,
 		"EventEmittedOnNoSignatureVerification":     testEventEmittedOnNoSignatureVerification,
 		"OneContainerWIthCosignRepository":          testOneContainerWithCosignRepository,
-		"OneContainerSinglePubKeyEnvRefRSA":         testOneContainerSinglePubKeyEnvRefRSA,
-		"TwoContainersSinglePubKeyEnvRefRSA":        TestTwoContainersSinglePubKeyEnvRefRSA,
+	}
+
+	fw, err := framework.New(t)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	for name, tf := range testFuncs {
-		t.Run(name, tf)
+		t.Run(name, tf(fw, framework.CreateECDSAKeyPair, name))
 	}
 }
 
 // TestFailingDeployments tests deployments that should fail signature verification
 func TestFailingDeployments(t *testing.T) {
-	testFuncs := map[string]func(t *testing.T){
+	testFuncs := map[string]func(fw *framework.Framework, kf framework.KeyFunc, key string) func(t *testing.T){
 		"OneContainerSinglePubKeyMalformedEnvRef":   testOneContainerSinglePubKeyMalformedEnvRef,
 		"TwoContainersSinglePubKeyMalformedEnvRef":  testTwoContainersSinglePubKeyMalformedEnvRef,
 		"OneContainerSinglePubKeyNoMatchEnvRef":     testOneContainerSinglePubKeyNoMatchEnvRef,
 		"OneContainerWithCosingRepoVariableMissing": testOneContainerWithCosingRepoVariableMissing,
 	}
 
+	fw, err := framework.New(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	for name, tf := range testFuncs {
-		t.Run(name, tf)
+		t.Run(name, tf(fw, framework.CreateECDSAKeyPair, name))
 	}
 }

--- a/test/main_test.go
+++ b/test/main_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/eumel8/cosignwebhook/test/framework"
@@ -26,7 +27,8 @@ func TestPassECDSA(t *testing.T) {
 	}
 
 	for name, tf := range testFuncs {
-		t.Run(name, tf(fw, framework.CreateECDSAKeyPair, name))
+		t.Run(fmt.Sprintf("[%s] %s", "ECDSA", name), tf(fw, framework.CreateECDSAKeyPair, name))
+		t.Run(fmt.Sprintf("[%s] %s", "RSA", name), tf(fw, framework.CreateRSAKeyPair, name))
 	}
 }
 
@@ -46,5 +48,6 @@ func TestFailingDeployments(t *testing.T) {
 
 	for name, tf := range testFuncs {
 		t.Run(name, tf(fw, framework.CreateECDSAKeyPair, name))
+		t.Run(name, tf(fw, framework.CreateRSAKeyPair, name))
 	}
 }

--- a/test/webhook_test.go
+++ b/test/webhook_test.go
@@ -62,7 +62,7 @@ func testOneContainerSinglePubKeyEnvRef(t *testing.T) {
 							Env: []corev1.EnvVar{
 								{
 									Name:  webhook.CosignEnvVar,
-									Value: pub,
+									Value: pub.Key,
 								},
 							},
 						},
@@ -123,7 +123,7 @@ func testTwoContainersSinglePubKeyEnvRef(t *testing.T) {
 							Env: []corev1.EnvVar{
 								{
 									Name:  webhook.CosignEnvVar,
-									Value: pub,
+									Value: pub.Key,
 								},
 							},
 						},
@@ -138,7 +138,7 @@ func testTwoContainersSinglePubKeyEnvRef(t *testing.T) {
 							Env: []corev1.EnvVar{
 								{
 									Name:  webhook.CosignEnvVar,
-									Value: pub,
+									Value: pub.Key,
 								},
 							},
 						},
@@ -174,7 +174,7 @@ func testOneContainerSinglePubKeySecretRef(t *testing.T) {
 			Namespace: "test-cases",
 		},
 		StringData: map[string]string{
-			"cosign.pub": pub,
+			"cosign.pub": pub.Key,
 		},
 	}
 
@@ -255,7 +255,7 @@ func testTwoContainersMixedPubKeyMixedRef(t *testing.T) {
 			Namespace: "test-cases",
 		},
 		StringData: map[string]string{
-			"cosign.pub": pub1,
+			"cosign.pub": pub1.Key,
 		},
 	}
 
@@ -277,7 +277,7 @@ func testTwoContainersMixedPubKeyMixedRef(t *testing.T) {
 					TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
 					Containers: []corev1.Container{
 						{
-							Name:  "two-containers-mixed-pub-keyrefs-first",
+							Name:  "two-containers-mixed-pub-keyrefs-from-secret",
 							Image: busyboxOne,
 							Command: []string{
 								"sh",
@@ -299,7 +299,7 @@ func testTwoContainersMixedPubKeyMixedRef(t *testing.T) {
 							},
 						},
 						{
-							Name:  "two-containers-mixed-pub-keyrefs-second",
+							Name:  "two-containers-mixed-pub-keyrefs-second-from-env",
 							Image: busyboxTwo,
 							Command: []string{
 								"sh",
@@ -309,7 +309,7 @@ func testTwoContainersMixedPubKeyMixedRef(t *testing.T) {
 							Env: []corev1.EnvVar{
 								{
 									Name:  webhook.CosignEnvVar,
-									Value: pub2,
+									Value: pub2.Key,
 								},
 							},
 						},
@@ -350,7 +350,7 @@ func testTwoContainersSinglePubKeyMixedRef(t *testing.T) {
 			Namespace: "test-cases",
 		},
 		StringData: map[string]string{
-			"cosign.pub": pub,
+			"cosign.pub": pub.Key,
 		},
 	}
 
@@ -404,7 +404,7 @@ func testTwoContainersSinglePubKeyMixedRef(t *testing.T) {
 							Env: []corev1.EnvVar{
 								{
 									Name:  webhook.CosignEnvVar,
-									Value: pub,
+									Value: pub.Key,
 								},
 							},
 						},
@@ -445,7 +445,7 @@ func testTwoContainersWithInitSinglePubKeyMixedRef(t *testing.T) {
 			Namespace: "test-cases",
 		},
 		StringData: map[string]string{
-			"cosign.pub": pub,
+			"cosign.pub": pub.Key,
 		},
 	}
 
@@ -501,7 +501,7 @@ func testTwoContainersWithInitSinglePubKeyMixedRef(t *testing.T) {
 							Env: []corev1.EnvVar{
 								{
 									Name:  webhook.CosignEnvVar,
-									Value: pub,
+									Value: pub.Key,
 								},
 							},
 						},
@@ -559,7 +559,7 @@ func testEventEmittedOnSignatureVerification(t *testing.T) {
 							Env: []corev1.EnvVar{
 								{
 									Name:  webhook.CosignEnvVar,
-									Value: pub,
+									Value: pub.Key,
 								},
 							},
 						},
@@ -641,7 +641,7 @@ func testOneContainerWithCosignRepository(t *testing.T) {
 			Namespace: "test-cases",
 		},
 		StringData: map[string]string{
-			"cosign.pub": pub,
+			"cosign.pub": pub.Key,
 		},
 	}
 
@@ -742,7 +742,7 @@ func testOneContainerSinglePubKeyEnvRefRSA(t *testing.T) {
 							Env: []corev1.EnvVar{
 								{
 									Name:  webhook.CosignEnvVar,
-									Value: pub,
+									Value: pub.Key,
 								},
 							},
 						},
@@ -764,7 +764,7 @@ func TestTwoContainersSinglePubKeyEnvRefRSA(t *testing.T) {
 	}
 
 	// Create a deployment with two containers signed by the same RSA key
-	_, rsaPub := fw.CreateRSAKeyPair(t, "test")
+	_, pub := fw.CreateRSAKeyPair(t, "test")
 	fw.SignContainer(t, framework.SignOptions{
 		KeyPath: fmt.Sprintf("test-%s.key", framework.ImportKeySuffix),
 		Image:   busyboxOne,
@@ -800,7 +800,7 @@ func TestTwoContainersSinglePubKeyEnvRefRSA(t *testing.T) {
 							Env: []corev1.EnvVar{
 								{
 									Name:  webhook.CosignEnvVar,
-									Value: rsaPub,
+									Value: pub.Key,
 								},
 							},
 						},
@@ -814,7 +814,7 @@ func TestTwoContainersSinglePubKeyEnvRefRSA(t *testing.T) {
 							Env: []corev1.EnvVar{
 								{
 									Name:  webhook.CosignEnvVar,
-									Value: rsaPub,
+									Value: pub.Key,
 								},
 							},
 						},
@@ -872,7 +872,7 @@ func testOneContainerSinglePubKeyNoMatchEnvRef(t *testing.T) {
 							Env: []corev1.EnvVar{
 								{
 									Name:  webhook.CosignEnvVar,
-									Value: other,
+									Value: other.Key,
 								},
 							},
 						},
@@ -888,7 +888,7 @@ func testOneContainerSinglePubKeyNoMatchEnvRef(t *testing.T) {
 }
 
 // testTwoContainersSinglePubKeyNoMatchEnvRef tests that a deployment with two signed containers,
-// with a public key provided via an environment variable, fails if one of the container's pub key is malformed.
+// with a public key provided via an environment variable, fails if one of the containers public key is malformed.
 func testTwoContainersSinglePubKeyMalformedEnvRef(t *testing.T) {
 	fw, err := framework.New()
 	if err != nil {
@@ -929,7 +929,7 @@ func testTwoContainersSinglePubKeyMalformedEnvRef(t *testing.T) {
 							Env: []corev1.EnvVar{
 								{
 									Name:  webhook.CosignEnvVar,
-									Value: pub,
+									Value: pub.Key,
 								},
 							},
 						},
@@ -1051,7 +1051,7 @@ func testOneContainerWithCosingRepoVariableMissing(t *testing.T) {
 							Env: []corev1.EnvVar{
 								{
 									Name:  webhook.CosignEnvVar,
-									Value: pub,
+									Value: pub.Key,
 								},
 							},
 						},

--- a/test/webhook_test.go
+++ b/test/webhook_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/eumel8/cosignwebhook/test/framework"
@@ -28,9 +27,9 @@ func testOneContainerSinglePubKeyEnvRef(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, pub := fw.CreateKeys(t, "test")
+	priv, pub := fw.CreateKeys(t, "test")
 	fw.SignContainer(t, framework.SignOptions{
-		KeyPath: "test.key",
+		KeyPath: priv.Path,
 		Image:   busyboxOne,
 	})
 
@@ -85,13 +84,13 @@ func testTwoContainersSinglePubKeyEnvRef(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, pub := fw.CreateKeys(t, "test")
+	priv, pub := fw.CreateKeys(t, "test")
 	fw.SignContainer(t, framework.SignOptions{
-		KeyPath: "test.key",
+		KeyPath: priv.Path,
 		Image:   busyboxOne,
 	})
 	fw.SignContainer(t, framework.SignOptions{
-		KeyPath: "test.key",
+		KeyPath: priv.Path,
 		Image:   busyboxTwo,
 	})
 
@@ -161,9 +160,9 @@ func testOneContainerSinglePubKeySecretRef(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, pub := fw.CreateKeys(t, "test")
+	priv, pub := fw.CreateKeys(t, "test")
 	fw.SignContainer(t, framework.SignOptions{
-		KeyPath: "test.key",
+		KeyPath: priv.Path,
 		Image:   busyboxOne,
 	})
 
@@ -237,14 +236,14 @@ func testTwoContainersMixedPubKeyMixedRef(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, pub1 := fw.CreateKeys(t, "test1")
-	_, pub2 := fw.CreateKeys(t, "test2")
+	priv1, pub1 := fw.CreateKeys(t, "test1")
+	priv2, pub2 := fw.CreateKeys(t, "test2")
 	fw.SignContainer(t, framework.SignOptions{
-		KeyPath: "test1.key",
+		KeyPath: priv1.Path,
 		Image:   busyboxOne,
 	})
 	fw.SignContainer(t, framework.SignOptions{
-		KeyPath: "test2.key",
+		KeyPath: priv2.Path,
 		Image:   busyboxTwo,
 	})
 
@@ -333,13 +332,13 @@ func testTwoContainersSinglePubKeyMixedRef(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, pub := fw.CreateKeys(t, "test")
+	priv, pub := fw.CreateKeys(t, "test")
 	fw.SignContainer(t, framework.SignOptions{
-		KeyPath: "test.key",
+		KeyPath: priv.Path,
 		Image:   busyboxOne,
 	})
 	fw.SignContainer(t, framework.SignOptions{
-		KeyPath: "test.key",
+		KeyPath: priv.Path,
 		Image:   busyboxTwo,
 	})
 
@@ -428,13 +427,13 @@ func testTwoContainersWithInitSinglePubKeyMixedRef(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, pub := fw.CreateKeys(t, "test")
+	priv, pub := fw.CreateKeys(t, "test")
 	fw.SignContainer(t, framework.SignOptions{
-		KeyPath: "test.key",
+		KeyPath: priv.Path,
 		Image:   busyboxOne,
 	})
 	fw.SignContainer(t, framework.SignOptions{
-		KeyPath: "test.key",
+		KeyPath: priv.Path,
 		Image:   busyboxTwo,
 	})
 
@@ -525,9 +524,9 @@ func testEventEmittedOnSignatureVerification(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, pub := fw.CreateKeys(t, "test")
+	priv, pub := fw.CreateKeys(t, "test")
 	fw.SignContainer(t, framework.SignOptions{
-		KeyPath: "test.key",
+		KeyPath: priv.Path,
 		Image:   busyboxOne,
 	})
 
@@ -627,9 +626,9 @@ func testOneContainerWithCosignRepository(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, pub := fw.CreateKeys(t, "test")
+	priv, pub := fw.CreateKeys(t, "test")
 	fw.SignContainer(t, framework.SignOptions{
-		KeyPath:       "test.key",
+		KeyPath:       priv.Path,
 		Image:         busyboxOne,
 		SignatureRepo: signatureRepo,
 	})
@@ -708,9 +707,9 @@ func testOneContainerSinglePubKeyEnvRefRSA(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, pub := fw.CreateRSAKeyPair(t, "test")
+	priv, pub := fw.CreateRSAKeyPair(t, "test")
 	fw.SignContainer(t, framework.SignOptions{
-		KeyPath: fmt.Sprintf("test-%s.key", framework.ImportKeySuffix),
+		KeyPath: priv.Path,
 		Image:   busyboxOne,
 	})
 
@@ -764,13 +763,13 @@ func TestTwoContainersSinglePubKeyEnvRefRSA(t *testing.T) {
 	}
 
 	// Create a deployment with two containers signed by the same RSA key
-	_, pub := fw.CreateRSAKeyPair(t, "test")
+	priv, pub := fw.CreateRSAKeyPair(t, "test")
 	fw.SignContainer(t, framework.SignOptions{
-		KeyPath: fmt.Sprintf("test-%s.key", framework.ImportKeySuffix),
+		KeyPath: priv.Path,
 		Image:   busyboxOne,
 	})
 	fw.SignContainer(t, framework.SignOptions{
-		KeyPath: fmt.Sprintf("test-%s.key", framework.ImportKeySuffix),
+		KeyPath: priv.Path,
 		Image:   busyboxTwo,
 	})
 
@@ -837,10 +836,10 @@ func testOneContainerSinglePubKeyNoMatchEnvRef(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, _ = fw.CreateKeys(t, "test")
-	_, other := fw.CreateKeys(t, "other")
+	priv, _ := fw.CreateKeys(t, "test")
+	_, otherPub := fw.CreateKeys(t, "other")
 	fw.SignContainer(t, framework.SignOptions{
-		KeyPath: "test.key",
+		KeyPath: priv.Path,
 		Image:   busyboxOne,
 	})
 
@@ -872,7 +871,7 @@ func testOneContainerSinglePubKeyNoMatchEnvRef(t *testing.T) {
 							Env: []corev1.EnvVar{
 								{
 									Name:  webhook.CosignEnvVar,
-									Value: other.Key,
+									Value: otherPub.Key,
 								},
 							},
 						},
@@ -895,9 +894,9 @@ func testTwoContainersSinglePubKeyMalformedEnvRef(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, pub := fw.CreateKeys(t, "test")
+	priv, pub := fw.CreateKeys(t, "test")
 	fw.SignContainer(t, framework.SignOptions{
-		KeyPath: "test.key",
+		KeyPath: priv.Path,
 		Image:   busyboxOne,
 	})
 
@@ -1018,9 +1017,9 @@ func testOneContainerWithCosingRepoVariableMissing(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, pub := fw.CreateKeys(t, "test")
+	priv, pub := fw.CreateKeys(t, "test")
 	fw.SignContainer(t, framework.SignOptions{
-		KeyPath:       "test.key",
+		KeyPath:       priv.Path,
 		Image:         busyboxOne,
 		SignatureRepo: signatureRepo,
 	})


### PR DESCRIPTION
Please merge before #59, as this is part of testing the feature introduced in the PR to solve #57. Once it's merged we can also merge 59 into main and do a release.

## Motivation

- The new RSA feature had to be thoroughly tested
- The tests had to be extended without greatly replicating the code

## Changes done

The E2E test cases were refactored to allow passing a signing function and the framework itself, to avoid having to create the framework in each test. Since the tests cases now don't just accept `testing.T` as an argument, they were refactored to return a function, so each case can still be run by calling `t.Run(testCase)`.

The next logical step seemed to be to wrap the `testing.T` type in our own `Framework`, as this is the role it principally plays: the testing framework for the E2E test cases. We let the `Framework` *centrally* take care of handling errors & checking whether a test passed or failed and skip micromanaging in each function of the Framework (each function did its own cleanup and called `t.Fatal` each time). We simplify the `Framework` by introducing graceful error handling (let everything fail and show first error) and letting each test case follow the same pattern:

- Prepare resources for test
- Sign images
- Do deployments & create any needed resources
- Do assertions
- Do cleanup

The `Framework` will do the rest. New tests just need to adhere to this pattern.

## Tests done 

- New E2E tests pass