### PR TITLE
More configuration options for the validatingwebhookconfiguration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,3 @@
-# build stage
-ARG HTTP_PROXY
-ARG HTTPS_PROXY
 FROM golang:1.23 AS build-env
 WORKDIR /app
 COPY  . /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 # build stage
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 FROM golang:1.23 AS build-env
 WORKDIR /app
 COPY  . /app

--- a/Makefile
+++ b/Makefile
@@ -74,3 +74,16 @@ e2e-cleanup:
 	@k3d cluster delete cosign-tests || echo "Deleting cosign tests k3d cluster failed. Continuing..."
 	@rm -f cosign.pub cosign.key second.pub second.key || echo "Removing files failed. Continuing..."
 	@echo "Done."
+
+#############
+### CHART ###
+#############
+
+.PHONY: chart-lint chart
+chart-lint:
+	@echo "Linting chart..."
+	@helm lint chart
+
+chart:
+	@echo "Packaging chart..."
+	@helm package chart

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: cosignwebhook
 description: A Helm chart for Cosign Webhook Admission Controller
 type: application
-version: 4.1.0
+version: 4.1.1
 appVersion: "4.3.0"
 maintainers:
-  - name: eumel8
-    email: f.kloeker@telekom.de
-    url: https://www.telekom.com
-  - name: puffitos
-    email: bruno.bressi@telekom.de
-    url: https://www.telekom.com
+- name: eumel8
+  email: f.kloeker@telekom.de
+  url: https://www.telekom.com
+- name: puffitos
+  email: bruno.bressi@telekom.de
+  url: https://www.telekom.com

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cosignwebhook
 description: A Helm chart for Cosign Webhook Admission Controller
 type: application
-version: 4.1.1-rc2
+version: 4.1.1
 appVersion: "4.3.0"
 maintainers:
 - name: eumel8

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cosignwebhook
 description: A Helm chart for Cosign Webhook Admission Controller
 type: application
-version: 4.1.1
+version: 4.1.1-rc1
 appVersion: "4.3.0"
 maintainers:
 - name: eumel8

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cosignwebhook
 description: A Helm chart for Cosign Webhook Admission Controller
 type: application
-version: 4.1.1-rc1
+version: 4.1.1-rc2
 appVersion: "4.3.0"
 maintainers:
 - name: eumel8

--- a/chart/templates/admission.yaml
+++ b/chart/templates/admission.yaml
@@ -21,12 +21,12 @@ webhooks:
   - admissionReviewVersions:
     - v1
     name: {{ .Values.admission.webhook.name }}
+    matchPolicy: {{ .Values.admission.matchPolicy }}
     namespaceSelector:
       matchExpressions:
         - key: kubernetes.io/metadata.name
           operator: NotIn
           values: [{{ .Release.Namespace | default "default" }}{{- if .Values.admission.exclude }},{{ .Values.admission.exclude }}{{- end }}]
-          objectSelector: {}
     clientConfig:
       service:
         name: {{ include "cosignwebhook.fullname" . }}
@@ -42,3 +42,4 @@ webhooks:
         scope: "*"
     failurePolicy: {{ .Values.admission.failurePolicy }}
     sideEffects: {{ .Values.admission.sideEffects }}
+    timeoutSeconds: {{ .Values.admission.timeoutSeconds }}

--- a/chart/templates/admission.yaml
+++ b/chart/templates/admission.yaml
@@ -40,6 +40,7 @@ webhooks:
         apiVersions: ["v1"]
         resources: ["pods"]
         scope: "*"
+    objectSelector: {}
     failurePolicy: {{ .Values.admission.failurePolicy }}
     sideEffects: {{ .Values.admission.sideEffects }}
     timeoutSeconds: {{ .Values.admission.timeoutSeconds }}

--- a/chart/templates/admission.yaml
+++ b/chart/templates/admission.yaml
@@ -26,16 +26,19 @@ webhooks:
         - key: kubernetes.io/metadata.name
           operator: NotIn
           values: [{{ .Release.Namespace | default "default" }}{{- if .Values.admission.exclude }},{{ .Values.admission.exclude }}{{- end }}]
+          objectSelector: {}
     clientConfig:
       service:
         name: {{ include "cosignwebhook.fullname" . }}
         namespace: {{ .Release.Namespace | default "default" }}
         path: "/validate"
+        port: 443
       caBundle: {{ $ca.Cert | b64enc }}
     rules:
       - operations: ["CREATE","UPDATE"]
         apiGroups: [""]
         apiVersions: ["v1"]
         resources: ["pods"]
+        scope: "*"
     failurePolicy: {{ .Values.admission.failurePolicy }}
     sideEffects: {{ .Values.admission.sideEffects }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -25,6 +25,9 @@ admission:
     name: webhook.example.com
   # list of excluded namespaces, comma-separated
   # exclude: default, kube-system, cattle-system
+  exclude: ""
+  matchPolicy: Equivalent
+  timeoutSeconds: 10
 
 podAnnotations: {}
 


### PR DESCRIPTION
## Motivation

Deploying this chart with GitOps operator (like Rancher's fleet) may cause some dissonance between the generated Manifests for the `ValidatingWebhookConfiguration` and the actual object, which has some additional fields present in its `spec` field.

Even though those fields are the sensible defaults today, the GitOps operator just does a simple diff between the expected helm-chart based manifest and the actual manifest and it's spotting a difference.

Adding those fields to the chart and also being able to manipulate them is something that serves a double purpose. Avoid the bug with any GitOps operators who can't do diffs and also allow our users to change the values of the validatingwebhookconfiguration, if needed.

## More details

A diff between the expected (what's generated from helm) and what's running shows what's missing. The metadata fields are ignored of course, but the spec isn't always ignored by fleet:

```bash
❯ sdiff ~/tmp/expected.yaml ~/tmp/current.yaml
apiVersion: admissionregistration.k8s.io/v1                     apiVersion: admissionregistration.k8s.io/v1
kind: ValidatingWebhookConfiguration                            kind: ValidatingWebhookConfiguration
metadata:                                                       metadata:
  annotations:                                                    annotations:
                                                              >     meta.helm.sh/release-name: cosignwebhook
                                                              >     meta.helm.sh/release-namespace: cosignwebhook
    objectset.rio.cattle.io/id: default-caas-cosignwebhook          objectset.rio.cattle.io/id: default-caas-cosignwebhook
                                                              >   creationTimestamp: "2023-12-11T08:24:07Z"
                                                              >   generation: 316
  labels:                                                         labels:
                                                              >     app.kubernetes.io/managed-by: Helm
    objectset.rio.cattle.io/hash: c6dafa8c92e593fa1c57fdac604       objectset.rio.cattle.io/hash: c6dafa8c92e593fa1c57fdac604
  name: cosignwebhook                                             name: cosignwebhook
                                                              >   resourceVersion: "475193184"
                                                              >   uid: 9094649d-0482-4882-ba08-3a2a24fb862e
webhooks:                                                       webhooks:
- admissionReviewVersions:                                      - admissionReviewVersions:
  - v1                                                            - v1
  clientConfig:                                                   clientConfig:
    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURJekN       caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURJekN
    service:                                                        service:
      name: cosignwebhook                                             name: cosignwebhook
      namespace: cosignwebhook                                        namespace: cosignwebhook
      path: /validate                                                 path: /validate
                                                              >       port: 443
  failurePolicy: Fail                                             failurePolicy: Fail
                                                              >   matchPolicy: Equivalent
  name: cosignwebhook.caas.telekom.de                             name: cosignwebhook.caas.telekom.de
  namespaceSelector:                                              namespaceSelector:
    matchExpressions:                                               matchExpressions:
    - key: kubernetes.io/metadata.name                              - key: kubernetes.io/metadata.name
      operator: NotIn                                                 operator: NotIn
      values:                                                         values:
      - cosignwebhook                                                 - cosignwebhook
      - default                                                       - default
      - kube-system                                                   - kube-system
      - cattle-system                                                 - cattle-system
                                                              >   objectSelector: {}
  rules:                                                          rules:
  - apiGroups:                                                    - apiGroups:
    - ""                                                            - ""
    apiVersions:                                                    apiVersions:
    - v1                                                            - v1
    operations:                                                     operations:
    - CREATE                                                        - CREATE
    - UPDATE                                                        - UPDATE
    resources:                                                      resources:
    - pods                                                          - pods
                                                              >     scope: '*'
  sideEffects: None                                               sideEffects: None
                                                              >   timeoutSeconds: 10
```

It can be argued, that is more of a fleet issue rather than a cosignwebhook per se, but adding the modification possibility to some of those fields is a quick and simple win.

## Changes

- Added the missing fields
- Added the standard values from our k8s clusters to the fields
- Added a simple make target to package and lint the chart

## Tests done

- [x] The rc2 candidate runs as expected in our staging environment
- [x] No more errors in our fleet gitops operator are to be seen

Signed-off-by: Bruno Bressi <bruno.bressi@telekom.de>