### PR TITLE
ci: upgrade GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,7 +58,8 @@ jobs:
             ${{ steps.meta.outputs.tags }}
       - name: Sign Push
         run: |
-          cosign sign --key env://COSIGN_KEY --tlog-upload=false ghcr.io/eumel8/cosignwebhook/cosignwebhook@${{ steps.build-push.outputs.digest }}
-          cosign sign --key env://COSIGN_KEY --tlog-upload=false mtr.devops.telekom.de/caas/cosignwebhook@${{ steps.build-push.outputs.digest }}
+          cosign signing-config create > signing-config.json
+          cosign sign --key env://COSIGN_KEY --signing-config signing-config.json ghcr.io/eumel8/cosignwebhook/cosignwebhook@${{ steps.build-push.outputs.digest }}
+          cosign sign --key env://COSIGN_KEY --signing-config signing-config.json mtr.devops.telekom.de/caas/cosignwebhook@${{ steps.build-push.outputs.digest }}
         env:
           COSIGN_KEY: ${{secrets.COSIGN_KEY}}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             mtr.devops.telekom.de/caas/cosignwebhook
@@ -30,23 +30,23 @@ jobs:
         with:
           cosign-release: "v3.0.6"
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to MTR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: mtr.devops.telekom.de
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         id: build-push
         with:
           context: .

--- a/.github/workflows/codacy.yaml
+++ b/.github/workflows/codacy.yaml
@@ -33,7 +33,7 @@ jobs:
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
       - name: Run Codacy Analysis CLI
@@ -53,6 +53,6 @@ jobs:
 
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -6,9 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Install go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: '1.25'
     - name: Install k3d

--- a/.github/workflows/gotest.yaml
+++ b/.github/workflows/gotest.yaml
@@ -4,9 +4,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v6
         with:
           go-version: 1.21
       - name: Mod Tidy

--- a/.github/workflows/gotest.yaml
+++ b/.github/workflows/gotest.yaml
@@ -8,7 +8,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.21
+          go-version: 1.25
       - name: Mod Tidy
         run: go mod tidy
       - name: Test

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Helm lint & package & push
         run: |
           curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -17,11 +17,11 @@ jobs:
         run: |
           curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
           helm version
-          helm registry login ${GHR} -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+          helm registry login ${GHR} -u ${{ github.repository_owner }} -p ${{ secrets.GITHUB_TOKEN }}
           helm registry login ${MTR} -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
           helm lint chart
           helm package chart
-          helm push $(ls *.tgz| head -1) oci://${GHR}/${{ github.actor }}/charts
+          helm push $(ls *.tgz| head -1) oci://${GHR}/${{ github.repository_owner }}/charts
           helm push $(ls *.tgz| head -1) oci://${MTR}/${REPO}/charts
         env:
           DOCKER_USERNAME: ${{secrets.DOCKER_USERNAME}}

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -21,17 +21,17 @@ jobs:
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     name: Build
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Build an image from Dockerfile
         run: |
           docker build -t docker.io/my-organization/my-app:${{ github.sha }} .
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: 'docker.io/my-organization/my-app:${{ github.sha }}'
           format: 'template'
@@ -40,6 +40,6 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## Summary
- Fixing chart push action to choose right org registry
- Upgrade to cosign v3 signing for cosignwebhook image
- Bump all GitHub Actions to their latest major versions (checkout v6, setup-go v6, docker/* v4/v6/v7, codeql-action v4)
- Upgrade trivy workflow runner from deprecated `ubuntu-20.04` to `ubuntu-24.04`
- Bump Go version in gotest workflow to 1.25

RC 5.1.0-rc0 has been tested successfully. This PR is prep for 5.1.0 release.

## Test plan
- [x] Build workflow runs successfully on push
- [x] End2end workflow runs successfully
- [x] Gotest workflow runs successfully
- [x] Helm, Codacy, and Trivy workflows run successfully