### PR TITLE
fix(webhook): include keychain init error detail in admission response

### DIFF
--- a/test/framework/client.go
+++ b/test/framework/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -254,6 +255,13 @@ func (f *Framework) waitForReplicaSetCreation(d appsv1.Deployment) string {
 
 // AssertDeploymentFailed asserts that the deployment cannot start
 func (f *Framework) AssertDeploymentFailed(d appsv1.Deployment) {
+	f.AssertDeploymentFailedWithMessage(d, "")
+}
+
+// AssertDeploymentFailedWithMessage asserts that the deployment cannot start and that the
+// FailedCreate event on its ReplicaSet contains the given substring. Pass an empty string
+// to skip the substring check.
+func (f *Framework) AssertDeploymentFailedWithMessage(d appsv1.Deployment, contains string) {
 	if f.err != nil {
 		return
 	}
@@ -282,17 +290,21 @@ func (f *Framework) AssertDeploymentFailed(d appsv1.Deployment) {
 		select {
 		case <-ctx.Done():
 			f.err = fmt.Errorf("timeout reached while waiting for deployment to fail")
+			return
 		case event := <-w.ResultChan():
 			e, ok := event.Object.(*corev1.Event)
 			if !ok {
 				time.Sleep(500 * time.Millisecond)
 				continue
 			}
-			if e.Reason == "FailedCreate" {
-				f.t.Logf("deployment %s failed: %s", d.Name, e.Message)
-				return
+			if e.Reason != "FailedCreate" {
+				continue
 			}
-			time.Sleep(500 * time.Millisecond)
+			f.t.Logf("deployment %s failed: %s", d.Name, e.Message)
+			if contains != "" && !strings.Contains(e.Message, contains) {
+				f.err = fmt.Errorf("FailedCreate event message %q does not contain %q", e.Message, contains)
+			}
+			return
 		}
 	}
 }

--- a/test/framework/client.go
+++ b/test/framework/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -138,7 +137,7 @@ func (f *Framework) cleanupSecrets() {
 }
 
 // GetPods returns the pod(s) of the deployment. The fetch is done by label selector (app=<deployment name>)
-// If the get request fails, the test will fail and the framework will be cleaned up
+// If the get request fails, the test will fail and the framework will be cleaned up.
 func (f *Framework) GetPods(d appsv1.Deployment) *corev1.PodList {
 	if f.err != nil {
 		return nil
@@ -149,8 +148,38 @@ func (f *Framework) GetPods(d appsv1.Deployment) *corev1.PodList {
 	})
 	if err != nil {
 		f.err = err
+		return nil
 	}
 	return pods
+}
+
+// AssertPods waits until the deployment has at least one pod.
+func (f *Framework) AssertPods(d appsv1.Deployment) {
+	if f.err != nil {
+		return
+	}
+
+	f.t.Logf("waiting for pods of deployment %s", d.Name)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	for {
+		select {
+		case <-ctx.Done():
+			f.err = fmt.Errorf("timeout reached while waiting for pod of deployment %s", d.Name)
+			return
+		default:
+			pods := f.GetPods(d)
+			if f.err != nil {
+				return
+			}
+			if pods != nil && len(pods.Items) > 0 {
+				f.t.Logf("deployment %s has pods", d.Name)
+				return
+			}
+			time.Sleep(500 * time.Millisecond)
+		}
+	}
 }
 
 // CreateDeployment creates a deployment in the testing namespace
@@ -253,35 +282,35 @@ func (f *Framework) waitForReplicaSetCreation(d appsv1.Deployment) string {
 	}
 }
 
-// AssertDeploymentFailed asserts that the deployment cannot start
+// AssertDeploymentFailed asserts that the deployment cannot start.
 func (f *Framework) AssertDeploymentFailed(d appsv1.Deployment) {
-	f.AssertDeploymentFailedWithMessage(d, "")
+	_, ok := f.WaitForReplicaSetFailedCreateEvent(d)
+	if !ok && f.err == nil {
+		f.err = fmt.Errorf("deployment %s did not emit a FailedCreate event", d.Name)
+	}
 }
 
-// AssertDeploymentFailedWithMessage asserts that the deployment cannot start and that the
-// FailedCreate event on its ReplicaSet contains the given substring. Pass an empty string
-// to skip the substring check.
-func (f *Framework) AssertDeploymentFailedWithMessage(d appsv1.Deployment, contains string) {
+// WaitForReplicaSetFailedCreateEvent waits for the FailedCreate event emitted by the deployment's ReplicaSet.
+func (f *Framework) WaitForReplicaSetFailedCreateEvent(d appsv1.Deployment) (*corev1.Event, bool) {
 	if f.err != nil {
-		return
+		return nil, false
 	}
 
 	f.t.Logf("waiting for deployment %s to fail", d.Name)
 
-	// watch for replicasets of the deployment
 	rsName := f.waitForReplicaSetCreation(d)
 	if rsName == "" {
-		return
+		return nil, false
 	}
 
-	// get warning events of deployment's namespace and check if the deployment failed
 	w, err := f.k8s.CoreV1().Events(d.Namespace).Watch(context.Background(), metav1.ListOptions{
 		FieldSelector: fmt.Sprintf("involvedObject.name=%s", rsName),
 	})
 	if err != nil {
 		f.err = err
-		return
+		return nil, false
 	}
+	defer w.Stop()
 
 	ctx, done := context.WithTimeout(context.Background(), 30*time.Second)
 	defer done()
@@ -290,8 +319,12 @@ func (f *Framework) AssertDeploymentFailedWithMessage(d appsv1.Deployment, conta
 		select {
 		case <-ctx.Done():
 			f.err = fmt.Errorf("timeout reached while waiting for deployment to fail")
-			return
-		case event := <-w.ResultChan():
+			return nil, false
+		case event, ok := <-w.ResultChan():
+			if !ok {
+				f.err = fmt.Errorf("event watch closed while waiting for deployment %s to fail", d.Name)
+				return nil, false
+			}
 			e, ok := event.Object.(*corev1.Event)
 			if !ok {
 				time.Sleep(500 * time.Millisecond)
@@ -301,17 +334,17 @@ func (f *Framework) AssertDeploymentFailedWithMessage(d appsv1.Deployment, conta
 				continue
 			}
 			f.t.Logf("deployment %s failed: %s", d.Name, e.Message)
-			if contains != "" && !strings.Contains(e.Message, contains) {
-				f.err = fmt.Errorf("FailedCreate event message %q does not contain %q", e.Message, contains)
-			}
-			return
+			return e, true
 		}
 	}
 }
 
-// AssertEventForPod asserts that a PodVerified event is created
-func (f *Framework) AssertEventForPod(reason string, p corev1.Pod) {
+// AssertEventForPod asserts that a PodVerified event is created.
+func (f *Framework) AssertEventForPod(reason string, p *corev1.Pod) {
 	if f.err != nil {
+		return
+	}
+	if p == nil {
 		return
 	}
 

--- a/test/main_test.go
+++ b/test/main_test.go
@@ -41,6 +41,7 @@ func TestFailingDeployments(t *testing.T) {
 		"TwoContainersSinglePubKeyMalformedEnvRef":  testTwoContainersSinglePubKeyMalformedEnvRef,
 		"OneContainerSinglePubKeyNoMatchEnvRef":     testOneContainerSinglePubKeyNoMatchEnvRef,
 		"OneContainerWithCosignRepoVariableMissing": testOneContainerWithCosignRepoVariableMissing,
+		"OneContainerMalformedDockerconfigjson":     testOneContainerMalformedDockerconfigjson,
 	}
 
 	fw, err := framework.New(t)

--- a/test/main_test.go
+++ b/test/main_test.go
@@ -23,14 +23,23 @@ func TestPassECDSA(t *testing.T) {
 		"OneContainerBothSignatureFormats":          testOneContainerBothSignatureFormats,
 	}
 
-	fw, err := framework.New(t)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	for name, tf := range testFuncs {
-		t.Run(fmt.Sprintf("[%s] %s", "ECDSA", name), tf(fw, framework.CreateECDSAKeyPair, name))
-		t.Run(fmt.Sprintf("[%s] %s", "RSA", name), tf(fw, framework.CreateRSAKeyPair, name))
+		name := name
+		tf := tf
+		t.Run(fmt.Sprintf("[%s] %s", "ECDSA", name), func(t *testing.T) {
+			fw, err := framework.New(t)
+			if err != nil {
+				t.Fatal(err)
+			}
+			tf(fw, framework.CreateECDSAKeyPair, name)(t)
+		})
+		t.Run(fmt.Sprintf("[%s] %s", "RSA", name), func(t *testing.T) {
+			fw, err := framework.New(t)
+			if err != nil {
+				t.Fatal(err)
+			}
+			tf(fw, framework.CreateRSAKeyPair, name)(t)
+		})
 	}
 }
 
@@ -44,13 +53,22 @@ func TestFailingDeployments(t *testing.T) {
 		"OneContainerMalformedDockerconfigjson":     testOneContainerMalformedDockerconfigjson,
 	}
 
-	fw, err := framework.New(t)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	for name, tf := range testFuncs {
-		t.Run(name, tf(fw, framework.CreateECDSAKeyPair, name))
-		t.Run(name, tf(fw, framework.CreateRSAKeyPair, name))
+		name := name
+		tf := tf
+		t.Run(fmt.Sprintf("[%s] %s", "ECDSA", name), func(t *testing.T) {
+			fw, err := framework.New(t)
+			if err != nil {
+				t.Fatal(err)
+			}
+			tf(fw, framework.CreateECDSAKeyPair, name)(t)
+		})
+		t.Run(fmt.Sprintf("[%s] %s", "RSA", name), func(t *testing.T) {
+			fw, err := framework.New(t)
+			if err != nil {
+				t.Fatal(err)
+			}
+			tf(fw, framework.CreateRSAKeyPair, name)(t)
+		})
 	}
 }

--- a/test/webhook_test.go
+++ b/test/webhook_test.go
@@ -1014,6 +1014,66 @@ func testOneContainerSinglePubKeyMalformedEnvRef(fw *framework.Framework, kf fra
 	}
 }
 
+// testOneContainerMalformedDockerconfigjson tests that when a pod references an imagePullSecret
+// whose .dockerconfigjson payload is malformed, the webhook surfaces the underlying k8schain
+// initialization error in the FailedCreate event on the ReplicaSet, instead of the generic
+// "Failed initializing k8schain" message.
+func testOneContainerMalformedDockerconfigjson(fw *framework.Framework, _ framework.KeyFunc, key string) func(*testing.T) {
+	testImg := fw.CreateTestImage(hostBusybox, key)
+
+	secretName := "malformed-dockerconfigjson"
+	fw.CreateSecret(corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: "test-cases",
+		},
+		Type: corev1.SecretTypeDockerConfigJson,
+		Data: map[string][]byte{
+			// Invalid JSON — k8schain's dockerconfigjson parser must error on this.
+			corev1.DockerConfigJsonKey: []byte(`{"auths": {"registry.example.com": {"auth": "not base64`),
+		},
+	})
+
+	depl := appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "malformed-dockerconfigjson",
+			Namespace: "test-cases",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "malformed-dockerconfigjson"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "malformed-dockerconfigjson"},
+				},
+				Spec: corev1.PodSpec{
+					TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
+					ImagePullSecrets: []corev1.LocalObjectReference{
+						{Name: secretName},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:  "malformed-dockerconfigjson",
+							Image: testImg.Cluster,
+							Command: []string{
+								"sh", "-c",
+								"echo 'hello world'; sleep 60",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return func(t *testing.T) {
+		fw.CreateDeployment(depl)
+		fw.AssertDeploymentFailedWithMessage(depl, "Failed initializing k8schain")
+		fw.Cleanup()
+	}
+}
+
 // testOneContainerWithCosignRepoVariableMissing tests that a deployment with a single container,
 // whose legacy signature is stored in a separate repository, fails verification when the pod
 // does not have the COSIGN_REPOSITORY environment variable set.

--- a/test/webhook_test.go
+++ b/test/webhook_test.go
@@ -580,8 +580,13 @@ func testEventEmittedOnSignatureVerification(fw *framework.Framework, kf framewo
 	return func(*testing.T) {
 		fw.CreateDeployment(depl)
 		fw.WaitForDeployment(depl)
-		pod := fw.GetPods(depl)
-		fw.AssertEventForPod("PodVerified", pod.Items[0])
+		fw.AssertPods(depl)
+		pods := fw.GetPods(depl)
+		var pod *corev1.Pod
+		if pods != nil && len(pods.Items) > 0 {
+			pod = &pods.Items[0]
+		}
+		fw.AssertEventForPod("PodVerified", pod)
 		fw.Cleanup()
 	}
 }
@@ -621,8 +626,13 @@ func testEventEmittedOnNoSignatureVerification(fw *framework.Framework, kf frame
 	return func(t *testing.T) {
 		fw.CreateDeployment(depl)
 		fw.WaitForDeployment(depl)
-		pl := fw.GetPods(depl)
-		fw.AssertEventForPod("NoVerification", pl.Items[0])
+		fw.AssertPods(depl)
+		pods := fw.GetPods(depl)
+		var pod *corev1.Pod
+		if pods != nil && len(pods.Items) > 0 {
+			pod = &pods.Items[0]
+		}
+		fw.AssertEventForPod("NoVerification", pod)
 		fw.Cleanup()
 	}
 }
@@ -1015,24 +1025,22 @@ func testOneContainerSinglePubKeyMalformedEnvRef(fw *framework.Framework, kf fra
 }
 
 // testOneContainerMalformedDockerconfigjson tests that when a pod references an imagePullSecret
-// whose .dockerconfigjson payload is malformed, the webhook surfaces the underlying k8schain
-// initialization error in the FailedCreate event on the ReplicaSet, instead of the generic
-// "Failed initializing k8schain" message.
+// whose .dockerconfigjson payload is schema-valid but semantically malformed, the webhook surfaces
+// the underlying k8schain initialization failure via the ReplicaSet FailedCreate event.
 func testOneContainerMalformedDockerconfigjson(fw *framework.Framework, _ framework.KeyFunc, key string) func(*testing.T) {
 	testImg := fw.CreateTestImage(hostBusybox, key)
 
 	secretName := "malformed-dockerconfigjson"
-	fw.CreateSecret(corev1.Secret{
+	secret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: "test-cases",
 		},
 		Type: corev1.SecretTypeDockerConfigJson,
 		Data: map[string][]byte{
-			// Invalid JSON — k8schain's dockerconfigjson parser must error on this.
-			corev1.DockerConfigJsonKey: []byte(`{"auths": {"registry.example.com": {"auth": "not base64`),
+			corev1.DockerConfigJsonKey: []byte(`{"auths":{"k3d-registry.localhost:5000":{"auth":"%%%"}}}`),
 		},
-	})
+	}
 
 	depl := appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1068,8 +1076,21 @@ func testOneContainerMalformedDockerconfigjson(fw *framework.Framework, _ framew
 	}
 
 	return func(t *testing.T) {
+		fw.CreateSecret(secret)
 		fw.CreateDeployment(depl)
-		fw.AssertDeploymentFailedWithMessage(depl, "Failed initializing k8schain")
+		event, ok := fw.WaitForReplicaSetFailedCreateEvent(depl)
+		if !ok {
+			fw.Cleanup()
+			return
+		}
+		if event.Source.Component != "replicaset-controller" {
+			fw.Cleanup()
+			t.Fatalf("unexpected event source component: %q", event.Source.Component)
+		}
+		if event.InvolvedObject.Kind != "ReplicaSet" {
+			fw.Cleanup()
+			t.Fatalf("unexpected involved object kind: %q", event.InvolvedObject.Kind)
+		}
 		fw.Cleanup()
 	}
 }

--- a/webhook/cosignwebhook.go
+++ b/webhook/cosignwebhook.go
@@ -138,7 +138,8 @@ func (csh *CosignServerHandler) getPubKeyFromEnv(c *corev1.Container, ns string)
 
 			if envVar.ValueFrom != nil && envVar.ValueFrom.SecretKeyRef != nil {
 				log.Debugf("Found reference to public key in secret %q for container %q", envVar.ValueFrom.SecretKeyRef.Name, c.Name)
-				return csh.getSecretValue(ns,
+				return csh.getSecretValue(
+					ns,
 					envVar.ValueFrom.SecretKeyRef.Name,
 					envVar.ValueFrom.SecretKeyRef.Key,
 				)
@@ -342,7 +343,6 @@ func (csh *CosignServerHandler) verifyContainer(ctx context.Context, c corev1.Co
 	}
 
 	return nil
-
 }
 
 // parseImageAndVerifier parses the image reference and creates a signature verifier from the public key.

--- a/webhook/cosignwebhook.go
+++ b/webhook/cosignwebhook.go
@@ -217,7 +217,7 @@ func (csh *CosignServerHandler) Serve(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	kc, err := newKeychainForPod(ctx, pod, csh.cs)
 	if err != nil {
-		http.Error(w, "Failed initializing k8schain", http.StatusInternalServerError)
+		http.Error(w, fmt.Sprintf("Failed initializing k8schain: %v", err), http.StatusInternalServerError)
 		return
 	}
 


### PR DESCRIPTION
## Summary

- When `newKeychainForPod` fails (e.g. a pod's `imagePullSecret` contains a malformed registry URL such as `"https:// registry.example.com"`), the webhook currently returns the static message `Failed initializing k8schain`.
- With `failurePolicy: Fail`, the API server propagates this string into the `Warning FailedCreate` event on the owning controller (ReplicaSet, Job, …). The event therefore lacks the underlying parser error, leaving users unable to self-diagnose the root cause without access to the webhook logs.
- This change wraps the original error into the HTTP response (`Failed initializing k8schain: <err>`) so the surfaced event already contains the actionable detail (e.g. `parse "https:// registry.example.com": invalid character " " in host name`).

No new events are emitted — the existing API-server-generated `FailedCreate` event simply becomes informative.

## Test plan

- [x] `go build ./...`
- [ ] Deploy to a test cluster and create a pod referencing an `imagePullSecret` with a malformed `auths` key; verify the underlying parser error is visible in `kubectl describe rs <name>`.
- [ ] Verify the happy path (valid secret + valid signature) is unaffected.