### PR TITLE
feat: route internet registry verification through proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,28 @@ The implementation is based on the cosign CLI's output transformation:
 
 - [cosign verify.go - transformOutput](https://github.com/sigstore/cosign/blob/b7462fb60764850a789392429d3ba40f969d07db/cmd/cosign/cli/verify/verify.go#L263)
 
+## Proxy for internet registries
+
+When images are hosted on registries reachable only through a forward proxy
+(e.g. public internet registries), the webhook can route its outbound image and
+signature requests through that proxy. The verification path honors the standard
+`HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment variables
+(via `http.ProxyFromEnvironment`).
+
+Enable it in the Helm chart and use `noProxy` to keep internal registries direct,
+so only non-`*.telekom.de` images are sent through the proxy:
+
+```yaml
+proxy:
+  enabled: true
+  httpsProxy: "http://proxy.telekom.de:8080"
+  httpProxy: "http://proxy.telekom.de:8080"
+  noProxy: ".telekom.de"
+```
+
+These values are injected into both the webhook container (runtime admission
+verification) and the image-verification init containers.
+
 ## Credits
 
 * Bruno Bressi <bruno.bressi@telekom.de>

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -35,6 +35,14 @@ spec:
           env:
           - name: COSIGNPUBKEY
             value: {{- toYaml .Values.cosign.key | indent 12 }}
+          {{- if .Values.proxy.enabled }}
+          - name: HTTP_PROXY
+            value: {{ .Values.proxy.httpProxy | quote }}
+          - name: HTTPS_PROXY
+            value: {{ .Values.proxy.httpsProxy | quote }}
+          - name: NO_PROXY
+            value: {{ .Values.proxy.noProxy | quote }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -100,7 +100,11 @@ tolerations: []
 
 affinity: {}
 
-# proxy configuration for outbound connections
+# proxy configuration for outbound connections (image and signature pulls).
+# When enabled, these env vars are injected into the webhook container and the
+# image-verification init containers. The verification path honors them via
+# http.ProxyFromEnvironment. Set noProxy to reach internal registries directly,
+# e.g. noProxy: ".telekom.de" routes only non-*.telekom.de images via the proxy.
 proxy:
   enabled: false
   httpProxy: ""

--- a/webhook/cosignwebhook.go
+++ b/webhook/cosignwebhook.go
@@ -370,7 +370,10 @@ func (csh *CosignServerHandler) parseImageAndVerifier(image, pubKey string) (nam
 // buildRemoteOpts constructs the remote options for registry access.
 func (*CosignServerHandler) buildRemoteOpts(kc authn.Keychain, env []corev1.EnvVar) ([]ociremote.Option, error) {
 	remoteOpts := []ociremote.Option{
-		ociremote.WithRemoteOptions(remote.WithAuthFromKeychain(kc)),
+		ociremote.WithRemoteOptions(
+			remote.WithAuthFromKeychain(kc),
+			remote.WithTransport(proxyTransport()),
+		),
 	}
 
 	if r := getCosignRepository(env); r != "" {
@@ -453,6 +456,21 @@ func (*CosignServerHandler) newVerifierForKey(publicKey crypto.PublicKey) (signa
 		log.Errorf("Unsupported public key type: %v", pub)
 		return nil, fmt.Errorf("unsupported public key type: %v", pub)
 	}
+}
+
+// proxyTransport returns an http.RoundTripper based on go-containerregistry's
+// DefaultTransport. It honors the standard HTTP_PROXY, HTTPS_PROXY and NO_PROXY
+// environment variables via http.ProxyFromEnvironment. This allows outbound
+// registry and signature traffic to be routed through a forward proxy for
+// images hosted on internet registries, while internal domains listed in
+// NO_PROXY (e.g. ".telekom.de") are reached directly.
+func proxyTransport() http.RoundTripper {
+	if t, ok := remote.DefaultTransport.(*http.Transport); ok {
+		tc := t.Clone()
+		tc.Proxy = http.ProxyFromEnvironment
+		return tc
+	}
+	return remote.DefaultTransport
 }
 
 // getCosignRepository returns the repository specified by the COSIGN_REPOSITORY environment variable


### PR DESCRIPTION
## Problem

The webhook could not verify images hosted on internet registries that are only reachable through a forward proxy. While the verification path (go-containerregistry's `DefaultTransport`) already honors `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` via `http.ProxyFromEnvironment`, those env vars were only injected into the **init containers** (which verify the webhook's own images at startup) — **not the main webhook container** that verifies pod images at admission time.

## Changes

- **chart/templates/deployment.yaml**: inject `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` into the main webhook container (gated by `proxy.enabled`), matching the init containers.
- **webhook/cosignwebhook.go**: make proxy support explicit and self-documenting via `proxyTransport()` (clones `remote.DefaultTransport` with `http.ProxyFromEnvironment`), wired into `buildRemoteOpts` through `remote.WithTransport`.
- **chart/values.yaml** + **README.md**: document the `.telekom.de` use case.

## Usage

Set `NO_PROXY` to reach internal registries directly so only non-`*.telekom.de` images go through the proxy:

```yaml
proxy:
  enabled: true
  httpsProxy: "http://proxy.telekom.de:8080"
  noProxy: ".telekom.de"
```

## Verification

- `go build ./...` ✅
- `go vet ./webhook/` ✅
- `go test ./webhook/` ✅
- `helm template` renders proxy env on the webhook container and both init containers ✅